### PR TITLE
Always return a list from a pipeline operation

### DIFF
--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -116,7 +116,8 @@ defmodule Redix.Connection do
   end
 
   defp format_resp(%Redix.Error{} = err), do: {:error, err}
-  defp format_resp(resp), do: {:ok, resp}
+  defp format_resp(resp) when is_list(resp), do: {:ok, resp}
+  defp format_resp(resp), do: {:ok, [resp]}
 
   defp reset_state(s) do
     %{s | queue: :queue.new, tail: "", socket: nil}

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -105,6 +105,11 @@ defmodule RedixTest do
     assert Redix.pipeline(c, commands) == {:ok, ["OK", 11, "11"]}
   end
 
+  test "pipeline/2: only one command should still return a list", %{conn: c} do
+    commands = [ ["SET", "pipe", "10"] ]
+    assert Redix.pipeline(c, commands) == {:ok, ["OK"]}
+  end
+
   test "pipeline/2: a lot of commands so that TCP gets stressed", %{conn: c} do
     assert {:ok, "OK"} = Redix.command(c, ~w(SET stress_pipeline foo))
 


### PR DESCRIPTION
Redix.pipeline currently returns a list when executing multiple commands but only a single answer when executing a single command. I found this quite surprising and provide this patch to always return a list.