### PR TITLE
Handle pipeline with no commands

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -315,7 +315,11 @@ defmodule Redix do
   @spec pipeline(GenServer.server, [command], Keyword.t) ::
     {:ok, [Redix.Protocol.redis_value]} |
     {:error, atom}
-  def pipeline(conn, commands, opts \\ []) do
+  def pipeline(conn, commands, opts \\ [])
+
+  def pipeline(_, [], _), do: {:ok, []}
+
+  def pipeline(conn, commands, opts) do
     Connection.call(conn, {:commands, commands}, opts[:timeout] || @default_timeout)
   end
 

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -121,6 +121,10 @@ defmodule RedixTest do
     assert Redix.pipeline(c, [["PING"]]) == {:ok, ["PONG"]}
   end
 
+  test "pipeline/2: no commands should still return an empty list of results", %{conn: c} do
+    assert Redix.pipeline(c, []) == {:ok, []}
+  end
+
   test "some commands: APPEND", %{conn: c} do
     assert Redix.command(c, ~w(APPEND to_append hello)) == {:ok, 5}
     assert Redix.command(c, ~w(APPEND to_append world)) == {:ok, 10}


### PR DESCRIPTION
For completeness sake, also handle `pipeline/2` with no commands.
This makes piping (`|>`) keys from one function into a pipeline command easier.