### PR TITLE
Add utils format error

### DIFF
--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -56,7 +56,7 @@ defmodule Redix.Connection do
 
   def disconnect({:error, reason} = _error, state) do
     Logger.error ["Disconnected from Redis (#{Utils.format_host(state)}): ",
-                  :inet.format_error(reason)]
+                  Utils.format_error(reason)]
 
     :gen_tcp.close(state.socket)
 

--- a/lib/redix/exceptions.ex
+++ b/lib/redix/exceptions.ex
@@ -13,6 +13,8 @@ defmodule Redix.ConnectionError do
   Error in the connection to Redis.
   """
 
+  alias Redix.Utils
+
   defexception [:message]
 
   def exception(reason) when is_binary(reason) do
@@ -24,5 +26,5 @@ defmodule Redix.ConnectionError do
   end
 
   defp format_reason(:empty_command), do: "an empty command ([]) is not a valid Redis command"
-  defp format_reason(other), do: :inet.format_error(other)
+  defp format_reason(other), do: Utils.format_error(other)
 end

--- a/lib/redix/pub_sub/connection.ex
+++ b/lib/redix/pub_sub/connection.ex
@@ -50,7 +50,7 @@ defmodule Redix.PubSub.Connection do
 
   def disconnect({:error, reason}, state) do
     Logger.error ["Disconnected from Redis (#{Utils.format_host(state)}): ",
-                  :inet.format_error(reason)]
+                  Utils.format_error(reason)]
     :gen_tcp.close(state.socket)
     state = disconnect_and_notify_clients(state, reason)
     Utils.backoff_or_stop(%{state | tail: "", socket: nil}, 0, reason)

--- a/lib/redix/utils.ex
+++ b/lib/redix/utils.ex
@@ -62,7 +62,7 @@ defmodule Redix.Utils do
         Auth.auth_and_select_db(%{state | socket: socket, reconnection_attempts: 0})
       {:error, reason} ->
         Logger.error ["Error connecting to Redis (#{format_host(state)}): ",
-                      :inet.format_error(reason)]
+                      format_error(reason)]
         handle_connection_error(state, info, reason)
     end
   end

--- a/lib/redix/utils.ex
+++ b/lib/redix/utils.ex
@@ -112,6 +112,18 @@ defmodule Redix.Utils do
     end
   end
 
+  @doc """
+  This function unwraps the actual reason if an 'unknown POSIX error' is returned
+  from :inet.format_error/1
+  """
+  @spec format_error(term) :: IO.chardata
+  def format_error(reason) do
+    case :inet.format_error(reason) do
+      'unknown POSIX error' -> inspect(reason)
+      message -> message
+    end
+  end
+
   defp attempt_to_reconnect?(%{opts: opts, reconnection_attempts: attempts}) do
     max_attempts = opts[:max_reconnection_attempts]
     is_nil(max_attempts) or (max_attempts > 0 and attempts <= max_attempts)

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -1,0 +1,13 @@
+defmodule Redix.UtilsTest do
+  use ExUnit.Case, async: true
+
+  import Redix.Utils
+
+  test "format_error/1 known error" do
+    assert format_error(:eaddrinuse) == 'address already in use'
+  end
+
+  test "format_error/1 unknown error" do
+    assert format_error(:unknown_error) == ":unknown_error"
+  end
+end


### PR DESCRIPTION
Hi there this is exactly what you proposed here: 

https://github.com/whatyouhide/redix/issues/20

Right out of the box if you run the tests without redis running you would get:

```
13:01:14.300 [error] Disconnected from Redis (localhost:6379): unknown POSIX error
```

Now:

```
13:03:57.329 [error] Disconnected from Redis (localhost:6379): :tcp_closed
```

We can probably make these reasons better to read by replacing them for human readable messages (TCP connection closed).

* [ ] Tests? Should I add a new `utils_test.exs`?