### PR TITLE
Fix command error in pipeline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ replies with a list of responses. They can be used in Redix via
 `Redix.pipeline/2-3`:
 
 ```elixir
-Redix.pipeline(conn, [~w(INCR foo), ~w(INCR foo), ~w(INCR foo 2)])
+Redix.pipeline(conn, [~w(INCR foo), ~w(INCR foo), ~w(INCRBY foo 2)])
 #=> {:ok, [1, 2, 4]}
 ```
 


### PR DESCRIPTION
[INCR](http://redis.io/commands/incr) only accepts a `key` argument.
[INCRBY](http://redis.io/commands/incrby) is the one which accepts `key` and `increment` arguments