### PR TITLE
Switch Travis CI badge to master branch...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redix
 
-[![Build Status](https://travis-ci.org/whatyouhide/redix.svg?branch=v0.1.0)](https://travis-ci.org/whatyouhide/redix)
+[![Build Status](https://travis-ci.org/whatyouhide/redix.svg?branch=master)](https://travis-ci.org/whatyouhide/redix)
 
 > Superfast, pipelined, resilient Redis client for Elixir.
 


### PR DESCRIPTION
The current batch is polling the v0.1.0 tag which is a bit behind master ;).