### PR TITLE
Introduced configuration support for Redis host and Redis port

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,7 @@
+use Mix.Config
+
+config :redix,
+  redis_host: 'localhost',
+  redis_port: 6379
+
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/lib/redix/utils.ex
+++ b/lib/redix/utils.ex
@@ -14,8 +14,8 @@ defmodule Redix.Utils do
 
   @redis_opts [:host, :port, :password, :database]
   @redis_default_opts [
-    host: 'localhost',
-    port: 6379,
+    host: Application.get_env(:redix, :redis_host),
+    port: Application.get_env(:redix, :redis_port)
   ]
 
   @redix_behaviour_opts [:socket_opts, :sync_connect, :backoff_initial, :backoff_max]

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -6,6 +6,9 @@ defmodule RedixTest do
 
   import Redix.TestHelpers
 
+  @redis_host Application.get_env(:redix, :redis_host)
+  @redis_port Application.get_env(:redix, :redis_port)
+
   setup_all do
     {:ok, conn} = Redix.start_link
     Redix.command!(conn, ["FLUSHDB"])
@@ -75,7 +78,7 @@ defmodule RedixTest do
 
   @tag :no_setup
   test "start_link/2: using a redis:// url" do
-    {:ok, pid} = Redix.start_link("redis://localhost:6379/3")
+    {:ok, pid} = Redix.start_link("redis://#{@redis_host}:#{@redis_port}/3")
     assert Redix.command(pid, ["PING"]) == {:ok, "PONG"}
   end
 
@@ -88,13 +91,13 @@ defmodule RedixTest do
 
   @tag :no_setup
   test "start_link/2: passing options along with a Redis URI" do
-    {:ok, pid} = Redix.start_link("redis://localhost:6379", name: :redix_uri)
+    {:ok, pid} = Redix.start_link("redis://#{@redis_host}:#{@redis_port}", name: :redix_uri)
     assert Process.whereis(:redix_uri) == pid
   end
 
   @tag :no_setup
   test "stop/1" do
-    {:ok, pid} = Redix.start_link("redis://localhost:6379/3")
+    {:ok, pid} = Redix.start_link("redis://#{@redis_host}:#{@redis_port}/3")
     assert Redix.stop(pid) == :ok
 
     Process.flag :trap_exit, true

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,10 +1,13 @@
 ExUnit.start()
 
-case :gen_tcp.connect('localhost', 6379, []) do
+
+redis_host = Application.get_env(:redix, :redis_host)
+redis_port = Application.get_env(:redix, :redis_port)
+case :gen_tcp.connect(redis_host, redis_port, []) do
   {:ok, socket} ->
     :gen_tcp.close(socket)
   {:error, reason} ->
-    Mix.raise "Cannot connect to Redis (http://localhost:6379): #{:inet.format_error(reason)}"
+    Mix.raise "Cannot connect to Redis (http://#{redis_host}:#{redis_port}): #{:inet.format_error(reason)}"
 end
 
 defmodule Redix.TestHelpers do


### PR DESCRIPTION
Introduced the common Elixir way for configuring the hostname and portnumber for the Redis server.

Using `:redis_host` and `:redis_port` can be used and are set to the default values `localhost` and `6379`, respectively.

Reason for this was executing the tests on a machine, where Redis is i.e. running in a non-local container.