### PR TITLE
Introduced environment variables for configuring the hostname and portnumber for the Redis server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ information on this.
 Clone the repository and run `$ mix test` to make sure everything is
 working. For tests to pass, you must have a Redis server running on `localhost`,
 port `6379`. Both may be configured using the environment variables `REDIS_HOST` and
-`REDIS_PORT` respectivly. Tests will wipe clean all the databases on the running Redis
+`REDIS_PORT` respectively. Tests will wipe clean all the databases on the running Redis
 server, as they call `FLUSHALL` multiple times, so *be careful*.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ information on this.
 
 Clone the repository and run `$ mix test` to make sure everything is
 working. For tests to pass, you must have a Redis server running on `localhost`,
-port `6379`. Tests will wipe clean all the databases on the running Redis
+port `6379`. Both may be configured using the environment variables `REDIS_HOST` and
+`REDIS_PORT` respectivly. Tests will wipe clean all the databases on the running Redis
 server, as they call `FLUSHALL` multiple times, so *be careful*.
 
 ## License

--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -81,9 +81,9 @@ defmodule Redix do
   Redis (instead of a URI as described above):
 
     * `:host` - (string) the host where the Redis server is running. Defaults to
-      `"localhost"`.
+      `"localhost"` or to whatever value the environment variable `REDIS_HOST` is set.
     * `:port` - (integer) the port on which the Redis server is
-      running. Defaults to `6379`.
+      running. Defaults to `6379`  or to whatever value the environment variable `REDIS_PORT` is set.
     * `:password` - (string) the password used to connect to Redis. Defaults to
       `nil`, meaning no password is used. When this option is provided, all Redix
       does is issue an `AUTH` command to Redis in order to authenticate.

--- a/lib/redix/utils.ex
+++ b/lib/redix/utils.ex
@@ -14,8 +14,8 @@ defmodule Redix.Utils do
 
   @redis_opts [:host, :port, :password, :database]
   @redis_default_opts [
-    host: 'localhost',
-    port: 6379,
+    host: System.get_env("REDIS_HOST") || "localhost" |> String.to_char_list,
+    port: System.get_env("REDIS_PORT") || 6379
   ]
 
   @redix_behaviour_opts [:socket_opts, :sync_connect, :backoff_initial, :backoff_max]

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -6,6 +6,10 @@ defmodule RedixTest do
 
   import Redix.TestHelpers
 
+  @redis_host System.get_env("REDIS_HOST") || "localhost" |> String.to_char_list
+  @redis_port System.get_env("REDIS_PORT") || 6379
+  @resis_host_and_port "#{@redis_host}:#{@redis_port}"
+
   setup_all do
     {:ok, conn} = Redix.start_link
     Redix.command!(conn, ["FLUSHDB"])
@@ -75,7 +79,7 @@ defmodule RedixTest do
 
   @tag :no_setup
   test "start_link/2: using a redis:// url" do
-    {:ok, pid} = Redix.start_link("redis://localhost:6379/3")
+    {:ok, pid} = Redix.start_link("redis://#{@resis_host_and_port}/3")
     assert Redix.command(pid, ["PING"]) == {:ok, "PONG"}
   end
 
@@ -88,13 +92,13 @@ defmodule RedixTest do
 
   @tag :no_setup
   test "start_link/2: passing options along with a Redis URI" do
-    {:ok, pid} = Redix.start_link("redis://localhost:6379", name: :redix_uri)
+    {:ok, pid} = Redix.start_link("redis://#{@resis_host_and_port}", name: :redix_uri)
     assert Process.whereis(:redix_uri) == pid
   end
 
   @tag :no_setup
   test "stop/1" do
-    {:ok, pid} = Redix.start_link("redis://localhost:6379/3")
+    {:ok, pid} = Redix.start_link("redis://#{@resis_host_and_port}/3")
     assert Redix.stop(pid) == :ok
 
     Process.flag :trap_exit, true

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,9 @@
 ExUnit.start()
 
-case :gen_tcp.connect('localhost', 6379, []) do
+redis_host = System.get_env("REDIS_HOST") |> String.to_char_list || 'localhost'
+redis_port = System.get_env("REDIS_PORT") || 6379
+
+case :gen_tcp.connect(redis_host, redis_port, []) do
   {:ok, socket} ->
     :gen_tcp.close(socket)
   {:error, reason} ->


### PR DESCRIPTION
Using `REDIS_HOST` and `REDIS_PORT` can be used and are set to the default values `localhost` and `6379`, respectively.

For example: `REDIS_HOST="192.168.99.100" mix test` if Redis is running on `192.168.99.100`.

Reason for this was executing the tests on a machine, where Redis is i.e. running in a non-local container.
