### PR TITLE
Fix HashSet deprecations for MapSet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ language:
 
 matrix:
   include:
-    - otp_release: 17.5
-      elixir: 1.0.5
-    - otp_release: 17.5
-      elixir: 1.1.1
-    - otp_release: 18.3
-      elixir: 1.1.1
     - otp_release: 18.3
       elixir: 1.2.6
     - otp_release: 18.3

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Redix.Mixfile do
   def project() do
     [app: :redix,
      version: @version,
-     elixir: "~> 1.0",
+     elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),


### PR DESCRIPTION
This PR removes the deprecations for HashSet Usage.

HashSet has been deprecated since Elixir 1.2 as Erlang 1.8 got a huge performance boost on maps.

MapSet is now the favored data structure for maps.

See :

https://github.com/elixir-lang/elixir/blob/v1.2.0/CHANGELOG.md#erlang-18-support
https://hexdocs.pm/elixir/MapSet.html

Errors that were caused at compile time :

```
warning: HashSet.new/0 is deprecated, use the MapSet module instead
  lib/redix/connection/shared_state.ex:14

warning: HashSet.put/2 is deprecated, use the MapSet module instead
  lib/redix/connection/shared_state.ex:56

warning: HashSet.delete/2 is deprecated, use the MapSet module instead
  lib/redix/connection/shared_state.ex:61

warning: HashSet.member?/2 is deprecated, use the MapSet module instead
  lib/redix/connection/shared_state.ex:81

warning: HashSet.member?/2 is deprecated, use the MapSet module instead
  lib/redix/connection/shared_state.ex:98

warning: HashSet.delete/2 is deprecated, use the MapSet module instead
  lib/redix/connection/shared_state.ex:99
``` 

Do note that this change requires to have elixir over 1.1 version which was released around September 28, 2015. Are we ok with dropping support of 1.0.5 as it's over a few years old or bumping the major version on next release @whatyouhide ?