### PR TITLE
Fix Redix.stop/1 to be synchronous and not leave zombie processes

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -166,8 +166,10 @@ defmodule Redix do
   @doc """
   Closes the connection to the Redis server.
 
-  This function is asynchronous: it returns `:ok` as soon as it's called and
-  performs the closing of the connection after that.
+  This function is synchronous and blocks until the given Redix connection frees
+  all its resources and disconnects from the Redis server. `timeout` can be
+  passed to limit the amout of time allowed for the connection to exit; if it
+  doesn't exit in the given interval, this call exits.
 
   ## Examples
 
@@ -175,9 +177,9 @@ defmodule Redix do
       :ok
 
   """
-  @spec stop(GenServer.server) :: :ok
-  def stop(conn) do
-    Redix.Connection.stop(conn)
+  @spec stop(GenServer.server, timeout) :: :ok
+  def stop(conn, timeout \\ :infinity) do
+    Redix.Connection.stop(conn, timeout)
   end
 
   @doc """

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -21,7 +21,6 @@ defmodule RedixTest do
       {:ok, %{}}
     else
       {:ok, conn} = Redix.start_link(host: @host, port: @port)
-      on_exit(fn -> Redix.stop(conn) end)
       {:ok, %{conn: conn}}
     end
   end
@@ -98,10 +97,10 @@ defmodule RedixTest do
   @tag :no_setup
   test "stop/1" do
     {:ok, pid} = Redix.start_link("redis://#{@host}:#{@port}/3")
+    ref = Process.monitor(pid)
     assert Redix.stop(pid) == :ok
 
-    Process.flag :trap_exit, true
-    assert_receive {:EXIT, ^pid, :normal}, 500
+    assert_receive {:DOWN, ^ref, _, _, :normal}, 500
   end
 
   @tag :no_setup


### PR DESCRIPTION
`Redix.Connection` starts two GenServers internally (both with `start_link`). However, these GenServers are not trapping exists, and thus they do not exit when `Redix.stop/1` is called, since that makes the `Redix.Connection` process exit with reason `:normal`. With this commit, I changed `Redix.stop/1` to be synchronous and use `GenServer.stop/3` (instead of stopping through a returned `:stop` tuple), and then I implemented the `terminate/2` callback for the `Redix.Connection` process: in this callback, I peacefully stop the two child GenServers (if the terminate reason is `:normal`) so that they're never orphaned because either the link will bring them down or we will manually.

\cc @fishcakez

Closes #45.