### PR TITLE
Start passing Redix.ConnectionError around instead of atoms

### DIFF
--- a/lib/redix/connection/shared_state.ex
+++ b/lib/redix/connection/shared_state.ex
@@ -79,7 +79,7 @@ defmodule Redix.Connection.SharedState do
       # the new set) because this process is going to die at the end of this
       # function anyways.
       unless MapSet.member?(state.timed_out_requests, request_id) do
-        Utils.reply_to_client(from, request_id, {:error, :disconnected})
+        Utils.reply_to_client(from, request_id, {:error, %Redix.ConnectionError{reason: :disconnected}})
       end
     end)
 

--- a/lib/redix/exceptions.ex
+++ b/lib/redix/exceptions.ex
@@ -1,6 +1,10 @@
 defmodule Redix.Error do
   @moduledoc """
   Error returned by Redis.
+
+  This exception represents semantic errors returned by Redis: for example,
+  non-existing commands or operations on keys with the wrong type (`INCR
+  not_an_integer`).
   """
 
   defexception [:message]
@@ -11,6 +15,31 @@ end
 defmodule Redix.ConnectionError do
   @moduledoc """
   Error in the connection to Redis.
+
+  This exception represents errors in the connection to Redis: for example,
+  request timeouts, disconnections, and similar.
+
+  ## Exception fields
+
+  This exception has the following public fields:
+
+    * `:reason` - (atom) the error reason. It can be one of the Redix-specific
+      reasons described in the "Error reasons" section below, or any error
+      reason returned by functions in the `:gen_tcp` module (see the
+      [`:inet.posix/0](http://www.erlang.org/doc/man/inet.html#type-posix) type.
+
+  ## Error reasons
+
+  The `:reason` field can assume a few Redix-specific values:
+
+    * `:closed`: when the connection to Redis is closed (and Redix is
+      reconnecting) and the user attempts to talk to Redis
+
+    * `:disconnected`: when the connection drops while a request to Redis is in
+      flight.
+
+    * `:timeout`: when Redis doesn't reply to the request in time.
+
   """
 
   defexception [:reason]

--- a/lib/redix/exceptions.ex
+++ b/lib/redix/exceptions.ex
@@ -13,10 +13,33 @@ defmodule Redix.ConnectionError do
   Error in the connection to Redis.
   """
 
-  defexception [:message]
+  defexception [:reason]
 
-  def exception(reason) when is_binary(reason),
-    do: %__MODULE__{message: reason}
-  def exception(reason),
-    do: %__MODULE__{message: Redix.format_error(reason)}
+  def message(%__MODULE__{reason: reason}) do
+    format_reason(reason)
+  end
+
+  @doc false
+  @spec format_reason(term) :: binary
+  def format_reason(reason)
+
+  # :inet.format_error/1 doesn't format :tcp_closed or :closed.
+  def format_reason(:tcp_closed) do
+    "TCP connection closed"
+  end
+
+  # Manually returned by us when the connection is closed and someone tries to
+  # send a command to Redis.
+  def format_reason(:closed) do
+    "the connection to Redis is closed"
+  end
+
+  def format_reason(reason) do
+    case :inet.format_error(reason) do
+      'unknown POSIX error' ->
+        inspect(reason)
+      message ->
+        List.to_string(message)
+    end
+  end
 end

--- a/pages/Reconnections.md
+++ b/pages/Reconnections.md
@@ -5,8 +5,8 @@ for some reason, a Redix process will try to reconnect to the Redis server.
 
 If there are pending requests to Redix (e.g., `Redix.command/2`s that haven't
 returned yet) when a disconnection happens, the `Redix` functions will return
-`{:error, :disconnected}` to the caller. The caller is responsible to retry the
-request if interested.
+`{:error, %Redix.ConnectionError{reason: :disconnected}}` to the caller. The
+caller is responsible to retry the request if interested.
 
 The first reconnection attempts happens after a backoff interval decided by the
 `:backoff_initial` option.  If this attempt succeeds, then Redix will start to

--- a/test/redix/connection_error_test.exs
+++ b/test/redix/connection_error_test.exs
@@ -1,0 +1,15 @@
+defmodule Redix.ConnectionErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Redix.ConnectionError
+
+  test "Exception.message/1 with a POSIX reason" do
+    assert Exception.message(%ConnectionError{reason: :eaddrinuse}) ==
+           "address already in use"
+  end
+
+  test "Exception.message/1 with an unknown reason" do
+    assert Exception.message(%ConnectionError{reason: :unknown}) ==
+           ":unknown"
+  end
+end


### PR DESCRIPTION
This commit is a breaking change: we start ditching simple atoms as errors (`{:error, :timeout}`) and start moving to `{:error, %Redix.ConnectionError{reason: :timeout}` errors. This has a few advantages:

  * raising errors is easier since we just need to raise the returned error

  * formatting errors is easier since the coherent and uniform `Exception.message/1` can be used on the returned error (since they are exceptions)

  * errors returned from Redix are clearly "marked" (with `Redix.`), as opposed to returning very generic errors such as `:timeout` or `:closed`