### PR TITLE
Adding support for `child_spec/1` that's arriving with Elixir 1.5.0

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -163,6 +163,26 @@ defmodule Redix do
     Redix.Connection.start_link(redis_opts, other_opts)
   end
 
+  @doc false
+  def child_spec([name: _] = arg), do: child_spec([[], arg])
+  @doc false
+  def child_spec([[name: _] = connection_opts]), do: child_spec([[], connection_opts])
+  @doc false 
+  def child_spec(uri) when is_binary(uri), do: child_spec([uri])
+  @doc false 
+  def child_spec(nil), do: child_spec([])    
+  @doc false
+  def child_spec(arg) when is_list(arg) do
+    %{
+      id:  __MODULE__,
+      start: {__MODULE__, :start_link, arg},
+      type: :worker
+    }
+  end
+
+
+
+
   @doc """
   Closes the connection to the Redis server.
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+  "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}

--- a/pages/Real-world usage.md
+++ b/pages/Real-world usage.md
@@ -37,7 +37,8 @@ is to have a named Redix process started under the supervision tree:
 
 ```elixir
 children = [
-  worker(Redix, [[], [name: :redix]]),
+  {Redix, name: redix}, #elixir >= 1.5.0
+  worker(Redix, [[], [name: :redix]]), #elixir <= 1.4.5
   # ...
 ]
 ```
@@ -64,7 +65,8 @@ name them `:redix_0` to `:redix_4`:
 # Create the redix children list of workers:
 pool_size = 5
 redix_workers = for i <- 0..(pool_size - 1) do
-  worker(Redix, [[], [name: :"redix_#{i}"]], id: {Redix, i})
+  {Redix, [[], [name: :"redix_#{i}"]]} |> Supervisor.child_spec(id: {Redix, i})   #elixir >= 1.5.0
+  worker(Redix, [[], [name: :"redix_#{i}"]], id: {Redix, i})   #elixir <= 1.4.5
 end
 ```
 

--- a/test/redix/child_spec_test.exs
+++ b/test/redix/child_spec_test.exs
@@ -1,0 +1,52 @@
+defmodule Redix.ChildSpecTests do
+    use ExUnit.Case, async: true
+
+        
+    test "child_spec with empty argument" do
+        assert Redix.child_spec([]) == %{
+            id: Redix,
+            start: {Redix, :start_link, []},
+            type: :worker
+        }
+    end
+
+    test "child_spec with only redis_opts" do
+        redis_opts = [host: "nonexistent"]
+        assert Redix.child_spec([redis_opts])[:start] == {Redix, :start_link, [redis_opts]}
+    end
+
+    test "child_spec with only connection_opts" do
+        connection_opts = [name: Redix]
+        assert Redix.child_spec([nil, connection_opts])[:start] == {Redix, :start_link, [nil, connection_opts]}
+        assert Redix.child_spec([[], connection_opts])[:start] == {Redix, :start_link, [[], connection_opts]}
+    end
+
+    test "child_spec with redis_opts and connection_opts" do
+        redis_opts = [host: "nonexistent"]
+        connection_opts = [name: Redix]
+        assert Redix.child_spec([redis_opts, connection_opts])[:start] == {Redix, :start_link, [redis_opts, connection_opts]}
+    end
+
+    test "child_spec with only name" do
+        connection_opts = [name: Redix]
+        assert Redix.child_spec(connection_opts)[:start] == {Redix, :start_link, [[], connection_opts]}
+    end
+
+    test "child_spec with only name nested in list" do
+        connection_opts = [name: Redix]
+        assert Redix.child_spec([connection_opts])[:start] == {Redix, :start_link, [[], connection_opts]}
+    end
+
+    test "child_spec with uri and name " do
+        uri = "redis://localhost:6379"
+        connection_opts = [name: Redix]
+        assert Redix.child_spec([uri, connection_opts])[:start] == {Redix, :start_link, [uri, connection_opts]}
+    end
+
+    test "child_spec with uri only " do
+        uri = "redis://localhost:6379"
+        assert Redix.child_spec(uri)[:start] == {Redix, :start_link, [uri]}
+    end
+
+
+end


### PR DESCRIPTION
Since this is a new feature, I'd thought we'd be liberal with what we accept but conservative with what the result is. 

The following are valid arguments, and it makes sure the result always fits `Redix.start_link/2`
```elixir
{Redix, nil}
{Redix, []}
{Redix, [[], [name: x ]]}
{Redix, [name: x]}
{Redix, ["redis://localhost:6379", name: x]}
{Redix, [redis_opts, [name: x]]}
{Redix, [[], [name: x ]]} |> Supervisor.child_spec(id: x) 
```