### PR TITLE
Mix config for redis url

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -172,15 +172,26 @@ defmodule Redix do
       {:ok, #PID<...>}
 
   """
-  @spec start_link(binary | Keyword.t, Keyword.t) :: GenServer.on_start
+  @spec start_link(binary | URI.t | Keyword.t, Keyword.t) :: GenServer.on_start
   def start_link(uri_or_redis_opts \\ [], connection_opts \\ [])
 
   def start_link(uri, other_opts) when is_binary(uri) and is_list(other_opts) do
-    uri |> Redix.URI.opts_from_uri() |> start_link(other_opts)
+    uri
+    |> Redix.URI.opts_from_uri()
+    |> start_link(other_opts)
+  end
+
+  def start_link(%URI{} = uri, other_opts) when is_list(other_opts) do
+    uri
+    |> Redix.URI.opts_from_uri()
+    |> start_link(other_opts)
   end
 
   def start_link(redis_opts, other_opts) do
-    Redix.Connection.start_link(redis_opts, other_opts)
+    Application.get_env(:redix, :url)
+    |> Redix.URI.opts_from_uri()
+    |> Keyword.merge(redis_opts)
+    |> Redix.Connection.start_link(other_opts)
   end
 
   @doc """

--- a/lib/redix/uri.ex
+++ b/lib/redix/uri.ex
@@ -8,10 +8,18 @@ defmodule Redix.URI do
     defexception [:message]
   end
 
-  @spec opts_from_uri(binary) :: Keyword.t
-  def opts_from_uri(uri) when is_binary(uri) do
-    %URI{host: host, port: port, scheme: scheme} = uri = URI.parse(uri)
+  @spec opts_from_uri(binary | URI.t | nil) :: Keyword.t
+  def opts_from_uri(uri)
 
+  def opts_from_uri(nil) do
+    []
+  end
+
+  def opts_from_uri(uri) when is_binary(uri) do
+    uri |> URI.parse() |> opts_from_uri()
+  end
+
+  def opts_from_uri(%URI{host: host, port: port, scheme: scheme} = uri) do
     unless scheme == "redis" do
       raise URIError, message: "expected scheme to be redis://, got: #{scheme}://"
     end

--- a/test/redix/uri_test.exs
+++ b/test/redix/uri_test.exs
@@ -4,6 +4,11 @@ defmodule Redix.URITest do
   import Redix.URI
   alias Redix.URI.URIError
 
+  test "opts_from_uri/1: nil" do
+    opts = opts_from_uri(nil)
+    assert [] == opts
+  end
+
   test "opts_from_uri/1: invalid scheme" do
     message = "expected scheme to be redis://, got: foo://"
     assert_raise URIError, message, fn ->
@@ -21,6 +26,14 @@ defmodule Redix.URITest do
 
   test "opts_from_uri/1: host and port" do
     opts = opts_from_uri("redis://localhost:6379")
+    assert opts[:host] == "localhost"
+    assert opts[:port] == 6379
+    assert is_nil(opts[:database])
+    assert is_nil(opts[:password])
+  end
+
+  test "opts_from_uri/1: URI host and port" do
+    opts = opts_from_uri(%URI{scheme: "redis", host: "localhost", port: 6379})
     assert opts[:host] == "localhost"
     assert opts[:port] == 6379
     assert is_nil(opts[:database])

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -18,6 +18,7 @@ defmodule RedixTest do
   end
 
   setup context do
+    Application.delete_env(:redix, :url)
     if context[:no_setup] do
       {:ok, %{}}
     else
@@ -81,6 +82,28 @@ defmodule RedixTest do
   @tag :no_setup
   test "start_link/2: using a redis:// url" do
     {:ok, pid} = Redix.start_link("redis://#{@host}:#{@port}/3")
+    assert Redix.command(pid, ["PING"]) == {:ok, "PONG"}
+  end
+
+  @tag :no_setup
+  test "start_link/2: using a mix config url" do
+    Application.put_env(:redix, :url, "redis://#{@host}:#{@port}/3")
+    {:ok, pid} = Redix.start_link()
+    assert Redix.command(pid, ["PING"]) == {:ok, "PONG"}
+  end
+
+  @tag :no_setup
+  test "start_link/2: using a redis:// uri" do
+    uri = %URI{scheme: "redis", host: @host, port: @port, path: "/3"}
+    {:ok, pid} = Redix.start_link(uri)
+    assert Redix.command(pid, ["PING"]) == {:ok, "PONG"}
+  end
+
+  @tag :no_setup
+  test "start_link/2: using a mix config uri" do
+    uri = %URI{scheme: "redis", host: @host, port: @port, path: "/3"}
+    Application.put_env(:redix, :url, uri)
+    {:ok, pid} = Redix.start_link()
     assert Redix.command(pid, ["PING"]) == {:ok, "PONG"}
   end
 


### PR DESCRIPTION
I added the possibility to also provide the an `URI` struct as redis url. This was connected to the possibility to read the url from the `Application` environment and thus provide it as `Mix` config.

    config :redix, :url, "redis://localhost:6379/3"