### PR TITLE
Document :timeout Redix.start_link/2 option

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -127,6 +127,8 @@ defmodule Redix do
       that are passed to `:gen_tcp.connect/4` when connecting to the Redis
       server. Some socket options (like `:active` or `:binary`) will be
       overridden by Redix so that it functions properly. Defaults to `[]`.
+    * `:timeout` - (integer) connection timeout (in milliseconds) also directly
+      passed to `:gen_tcp.connect/4`. Defaults to `5000`.
     * `:sync_connect` - (boolean) decides whether Redix should initiate the TCP
       connection to the Redis server *before* or *after* returning from
       `start_link/2`. This option also changes some reconnection semantics; read


### PR DESCRIPTION
Hello!

There is an important option when establishing a connection to Redis: connect timeout. It is actually implemented (https://github.com/whatyouhide/redix/blob/master/lib/redix/utils.ex#L71), but the documentations says nothing about it. I tried to add missing docs.

Thanks for the great Elixir-native Redis client!