### PR TITLE
Make all @spec methods into behaviours.

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -174,6 +174,7 @@ defmodule Redix do
 
   """
   @spec start_link(binary | Keyword.t(), Keyword.t()) :: GenServer.on_start()
+  @callback start_link(binary | Keyword.t(), Keyword.t()) :: GenServer.on_start()
   def start_link(uri_or_redis_opts \\ [], connection_opts \\ [])
 
   def start_link(uri, other_opts) when is_binary(uri) and is_list(other_opts) do
@@ -199,6 +200,7 @@ defmodule Redix do
 
   """
   @spec stop(GenServer.server(), timeout) :: :ok
+  @callback stop(GenServer.server(), timeout) :: :ok
   def stop(conn, timeout \\ :infinity) do
     Redix.Connection.stop(conn, timeout)
   end
@@ -248,6 +250,8 @@ defmodule Redix do
   """
   @spec pipeline(GenServer.server(), [command], Keyword.t()) ::
           {:ok, [Redix.Protocol.redis_value()]} | {:error, atom}
+  @callback pipeline(GenServer.server(), [command], Keyword.t()) ::
+          {:ok, [Redix.Protocol.redis_value()]} | {:error, atom}
   def pipeline(conn, commands, opts \\ []) do
     assert_valid_pipeline_commands(commands)
     Redix.Connection.pipeline(conn, commands, opts[:timeout] || @default_timeout)
@@ -291,6 +295,8 @@ defmodule Redix do
 
   """
   @spec pipeline!(GenServer.server(), [command], Keyword.t()) ::
+          [Redix.Protocol.redis_value()] | no_return
+  @callback pipeline!(GenServer.server(), [command], Keyword.t()) ::
           [Redix.Protocol.redis_value()] | no_return
   def pipeline!(conn, commands, opts \\ []) do
     case pipeline(conn, commands, opts) do
@@ -348,6 +354,8 @@ defmodule Redix do
   """
   @spec command(GenServer.server(), command, Keyword.t()) ::
           {:ok, Redix.Protocol.redis_value()} | {:error, atom | Redix.Error.t()}
+  @callback command(GenServer.server(), command, Keyword.t()) ::
+          {:ok, Redix.Protocol.redis_value()} | {:error, atom | Redix.Error.t()}
   def command(conn, command, opts \\ []) do
     case pipeline(conn, [command], opts) do
       {:ok, [%Redix.Error{} = error]} ->
@@ -397,6 +405,8 @@ defmodule Redix do
 
   """
   @spec command!(GenServer.server(), command, Keyword.t()) ::
+          Redix.Protocol.redis_value() | no_return
+  @callback command!(GenServer.server(), command, Keyword.t()) ::
           Redix.Protocol.redis_value() | no_return
   def command!(conn, command, opts \\ []) do
     case command(conn, command, opts) do

--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -30,17 +30,21 @@ defmodule Redix.Connection do
   ## Public API
 
   @spec start_link(Keyword.t(), Keyword.t()) :: GenServer.on_start()
+  @callback start_link(Keyword.t(), Keyword.t()) :: GenServer.on_start()
   def start_link(redis_opts, other_opts) do
     {redix_opts, connection_opts} = Utils.sanitize_starting_opts(redis_opts, other_opts)
     Connection.start_link(__MODULE__, redix_opts, connection_opts)
   end
 
   @spec stop(GenServer.server(), timeout) :: :ok
+  @callback stop(GenServer.server(), timeout) :: :ok
   def stop(conn, timeout) do
     GenServer.stop(conn, :normal, timeout)
   end
 
   @spec pipeline(GenServer.server(), [Redix.command()], timeout) ::
+          {:ok, [Redix.Protocol.redis_value()]} | {:error, atom}
+  @callback pipeline(GenServer.server(), [Redix.command()], timeout) ::
           {:ok, [Redix.Protocol.redis_value()]} | {:error, atom}
   def pipeline(conn, commands, timeout) do
     request_id = make_ref()

--- a/lib/redix/connection/receiver.ex
+++ b/lib/redix/connection/receiver.ex
@@ -22,11 +22,13 @@ defmodule Redix.Connection.Receiver do
   ## Public API
 
   @spec start_link(Keyword.t()) :: GenServer.on_start()
+  @callback start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)
   end
 
   @spec stop(GenServer.server()) :: :ok
+  @callback stop(GenServer.server()) :: :ok
   def stop(pid) do
     GenServer.cast(pid, :stop)
   end

--- a/lib/redix/connection/shared_state.ex
+++ b/lib/redix/connection/shared_state.ex
@@ -13,31 +13,37 @@ defmodule Redix.Connection.SharedState do
   ## Public API
 
   @spec start_link() :: GenServer.on_start()
+  @callback start_link() :: GenServer.on_start()
   def start_link() do
     GenServer.start_link(__MODULE__, nil)
   end
 
   @spec enqueue(GenServer.server(), client) :: :ok
+  @callback enqueue(GenServer.server(), client) :: :ok
   def enqueue(pid, client) do
     GenServer.cast(pid, {:enqueue, client})
   end
 
   @spec dequeue(GenServer.server()) :: {boolean, client}
+  @callback dequeue(GenServer.server()) :: {boolean, client}
   def dequeue(pid) do
     GenServer.call(pid, :dequeue)
   end
 
   @spec add_timed_out_request(GenServer.server(), reference) :: :ok
+  @callback add_timed_out_request(GenServer.server(), reference) :: :ok
   def add_timed_out_request(pid, request_id) do
     GenServer.call(pid, {:add_timed_out_request, request_id})
   end
 
   @spec cancel_timed_out_request(GenServer.server(), reference) :: :ok
+  @callback cancel_timed_out_request(GenServer.server(), reference) :: :ok
   def cancel_timed_out_request(pid, request_id) do
     GenServer.call(pid, {:cancel_timed_out_request, request_id})
   end
 
   @spec disconnect_clients_and_stop(GenServer.server()) :: :ok
+  @callback disconnect_clients_and_stop(GenServer.server()) :: :ok
   def disconnect_clients_and_stop(pid) do
     GenServer.call(pid, :disconnect_clients_and_stop)
   end

--- a/lib/redix/exceptions.ex
+++ b/lib/redix/exceptions.ex
@@ -50,6 +50,7 @@ defmodule Redix.ConnectionError do
 
   @doc false
   @spec format_reason(term) :: binary
+  @callback format_reason(term) :: binary
   def format_reason(reason)
 
   # :inet.format_error/1 doesn't format :tcp_closed.

--- a/lib/redix/protocol.ex
+++ b/lib/redix/protocol.ex
@@ -36,6 +36,7 @@ defmodule Redix.Protocol do
 
   """
   @spec pack([binary]) :: iodata
+  @callback pack([binary]) :: iodata
   def pack(items) when is_list(items) do
     {packed, size} =
       Enum.map_reduce(items, 0, fn item, acc ->
@@ -67,6 +68,7 @@ defmodule Redix.Protocol do
 
   """
   @spec parse(binary) :: on_parse(redis_value)
+  @callback parse(binary) :: on_parse(redis_value)
   def parse(data)
 
   def parse("+" <> rest), do: parse_simple_string(rest)
@@ -99,6 +101,7 @@ defmodule Redix.Protocol do
 
   """
   @spec parse_multi(binary, non_neg_integer) :: on_parse([redis_value])
+  @callback parse_multi(binary, non_neg_integer) :: on_parse([redis_value])
   def parse_multi(data, nelems)
 
   # We treat the case when we have just one element to parse differently as it's

--- a/lib/redix/uri.ex
+++ b/lib/redix/uri.ex
@@ -9,6 +9,7 @@ defmodule Redix.URI do
   end
 
   @spec opts_from_uri(binary) :: Keyword.t()
+  @callback opts_from_uri(binary) :: Keyword.t()
   def opts_from_uri(uri) when is_binary(uri) do
     %URI{host: host, port: port, scheme: scheme} = uri = URI.parse(uri)
 

--- a/lib/redix/utils.ex
+++ b/lib/redix/utils.ex
@@ -35,6 +35,7 @@ defmodule Redix.Utils do
   @default_timeout 5000
 
   @spec sanitize_starting_opts(Keyword.t(), Keyword.t()) :: {Keyword.t(), Keyword.t()}
+  @callback sanitize_starting_opts(Keyword.t(), Keyword.t()) :: {Keyword.t(), Keyword.t()}
   def sanitize_starting_opts(redis_opts, other_opts)
       when is_list(redis_opts) and is_list(other_opts) do
     check_redis_opts(redis_opts)
@@ -64,6 +65,7 @@ defmodule Redix.Utils do
   end
 
   @spec connect(Keyword.t()) :: {:ok, :gen_tcp.socket()} | {:error, term} | {:stop, term, %{}}
+  @callback connect(Keyword.t()) :: {:ok, :gen_tcp.socket()} | {:error, term} | {:stop, term, %{}}
   def connect(opts) do
     host = opts |> Keyword.fetch!(:host) |> String.to_charlist()
     port = Keyword.fetch!(opts, :port)
@@ -85,6 +87,7 @@ defmodule Redix.Utils do
   end
 
   @spec format_host(Redix.Connection.state()) :: String.t()
+  @callback format_host(Redix.Connection.state()) :: String.t()
   def format_host(%{opts: opts} = _state) do
     "#{opts[:host]}:#{opts[:port]}"
   end


### PR DESCRIPTION
This change allows projects that use Redix to cleanly mock the Redis interactions in their test suite via libraries such as [Mox](https://github.com/plataformatec/mox).