### PR TITLE
Fix spec for Connection Timeout

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -247,7 +247,7 @@ defmodule Redix do
 
   """
   @spec pipeline(GenServer.server(), [command], Keyword.t()) ::
-          {:ok, [Redix.Protocol.redis_value()]} | {:error, atom}
+          {:ok, [Redix.Protocol.redis_value()]} | {:error, atom | Redix.Error.t()}
   def pipeline(conn, commands, opts \\ []) do
     assert_valid_pipeline_commands(commands)
     Redix.Connection.pipeline(conn, commands, opts[:timeout] || @default_timeout)

--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -41,7 +41,7 @@ defmodule Redix.Connection do
   end
 
   @spec pipeline(GenServer.server(), [Redix.command()], timeout) ::
-          {:ok, [Redix.Protocol.redis_value()]} | {:error, atom}
+          {:ok, [Redix.Protocol.redis_value()]} | {:error, atom | Redix.Error.t()}
   def pipeline(conn, commands, timeout) do
     request_id = make_ref()
 


### PR DESCRIPTION
Regarding the documentation, the pipeline method can return not only atom but also a Redix.Error.t, but the spec only contains the atom case.

```
defmodule RedixIssue do

  def hello do
    {:ok, conn} = Redix.start_link()
    case Redix.command(conn, ["PING"]) do
      {:ok, "PONG"} -> :ok
      {:error, error} when is_atom(error)-> {:error, Atom.to_string(error)}
      {:error, error} -> {:error, Exception.message(error)}
    end
  end
end
```

```
> mix dialyzer

lib/redix_issue.ex:8: The pattern {'error', Verror@2} can never match the type {'ok','nil' | binary() | ['nil' | binary() | [any()] | integer() | #{'__exception__':=_, '__struct__':='Elixir.Redix.Error', 'message':=binary()}] | integer() | #{'__exception__':=_, '__struct__':='Elixir.Redix.Error', 'message':=binary()}}
```

Example Issue Repo https://github.com/oliver-schoenherr/redix-issue