### PR TITLE
Make sure starting options is a keyword list

### DIFF
--- a/lib/redix/utils.ex
+++ b/lib/redix/utils.ex
@@ -116,7 +116,7 @@ defmodule Redix.Utils do
 
   defp check_redis_opts(opts) when is_list(opts) do
     unless Keyword.keyword?(opts) do
-        raise ArgumentError, "expected a keyword list as options, got: #{inspect(opts)}"
+      raise ArgumentError, "expected a keyword list as options, got: #{inspect(opts)}"
     end
 
     Enum.each(opts, fn {option, _value} ->

--- a/lib/redix/utils.ex
+++ b/lib/redix/utils.ex
@@ -115,6 +115,10 @@ defmodule Redix.Utils do
   end
 
   defp check_redis_opts(opts) when is_list(opts) do
+    unless Keyword.keyword?(opts) do
+        raise ArgumentError, "expected a keyword list as options, got: #{inspect(opts)}"
+    end
+
     Enum.each(opts, fn {option, _value} ->
       unless option in @redis_opts do
         raise ArgumentError,

--- a/test/redix/utils_test.exs
+++ b/test/redix/utils_test.exs
@@ -7,23 +7,38 @@ defmodule Redix.UtilsTest do
     assert format_host(%{opts: [host: 'example.com', port: 6379]}) == "example.com:6379"
   end
 
-  test "sanitize_starting_opts/2" do
-    redis_opts = [host: "foo.com"]
-    other_opts = [backoff_max: 0, sync_connect: true, name: :redix]
-    assert {redix_opts, connection_opts} = sanitize_starting_opts(redis_opts, other_opts)
-    assert redix_opts[:host] == 'foo.com'
-    assert redix_opts[:backoff_max] == 0
-    assert redix_opts[:sync_connect] == true
-    assert connection_opts[:name] == :redix
+  describe "sanitize_starting_opts/2" do
+    test "correct options are parsed" do
+      redis_opts = [host: "foo.com"]
+      other_opts = [backoff_max: 0, sync_connect: true, name: :redix]
 
-    assert_raise ArgumentError, ~r/unknown Redis connection option: :foo/, fn ->
-      sanitize_starting_opts([foo: 1], [])
+      assert {redix_opts, connection_opts} = sanitize_starting_opts(redis_opts, other_opts)
+      assert redix_opts[:host] == 'foo.com'
+      assert redix_opts[:backoff_max] == 0
+      assert redix_opts[:sync_connect] == true
+      assert connection_opts[:name] == :redix
     end
 
-    message = "expected an integer as the value of the :port option, got: %{}"
+    test "raise ArgumentError on unknown option" do
+      assert_raise ArgumentError, ~r/unknown Redis connection option: :foo/, fn ->
+        sanitize_starting_opts([foo: 1], [])
+      end
+    end
 
-    assert_raise ArgumentError, message, fn ->
-      sanitize_starting_opts([port: %{}], [])
+    test "raise ArgumentError on incorrect type" do
+      message = "expected an integer as the value of the :port option, got: %{}"
+
+      assert_raise ArgumentError, message, fn ->
+        sanitize_starting_opts([port: %{}], [])
+      end
+    end
+
+    test "raise ArgumentError on non-keyword list" do
+      message = "expected a keyword list as options, got: [\"foo.com\"]"
+
+      assert_raise ArgumentError, message, fn ->
+        sanitize_starting_opts(["foo.com"], [])
+      end
     end
   end
 end


### PR DESCRIPTION
I accidentally put the connection uri as part of the options when starting some redix workers and got a `FunctionClauseError`. This PR checks that the options is a keyword list, maybe it can save someone else some time if they make the same mistake :)