### PR TITLE
Add fallback `handle_info` definition to Redix.Connection

### DIFF
--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -261,6 +261,10 @@ defmodule Redix.Connection do
     {:disconnect, {:error, %ConnectionError{reason: reason}}, state}
   end
 
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
   def terminate(reason, %{receiver: receiver, shared_state: shared_state} = _state) do
     if reason == :normal do
       :ok = GenServer.stop(receiver, :normal)


### PR DESCRIPTION
Hopefully Fixes https://github.com/whatyouhide/redix/issues/72

It is just a hunch, but I do believe that the genserver might be receiving the same disconnection message more than once. The first one updates the state to nil. The others won't match anymore.

A simple default handle_info clause that doesn't do anything (just like the default one), should fix this behavior.