### PR TITLE
Fix badmatch when setting up the SSL buffers

### DIFF
--- a/lib/redix/utils.ex
+++ b/lib/redix/utils.ex
@@ -120,9 +120,9 @@ defmodule Redix.Utils do
     inet_mod = if transport == :ssl, do: :ssl, else: :inet
 
     with {:ok, opts} <- inet_mod.getopts(socket, [:sndbuf, :recbuf, :buffer]) do
-      sndbuf = Keyword.get(opts, :sndbuf)
-      recbuf = Keyword.get(opts, :recbuf)
-      buffer = Keyword.get(opts, :buffer)
+      sndbuf = Keyword.fetch!(opts, :sndbuf)
+      recbuf = Keyword.fetch!(opts, :recbuf)
+      buffer = Keyword.fetch!(opts, :buffer)
       inet_mod.setopts(socket, buffer: buffer |> max(sndbuf) |> max(recbuf))
     end
   end

--- a/lib/redix/utils.ex
+++ b/lib/redix/utils.ex
@@ -120,7 +120,9 @@ defmodule Redix.Utils do
     inet_mod = if transport == :ssl, do: :ssl, else: :inet
 
     with {:ok, opts} <- inet_mod.getopts(socket, [:sndbuf, :recbuf, :buffer]) do
-      [sndbuf: sndbuf, recbuf: recbuf, buffer: buffer] = opts
+      sndbuf = Keyword.get(opts, :sndbuf)
+      recbuf = Keyword.get(opts, :recbuf)
+      buffer = Keyword.get(opts, :buffer)
       inet_mod.setopts(socket, buffer: buffer |> max(sndbuf) |> max(recbuf))
     end
   end


### PR DESCRIPTION
:ssl.getopts does not always return the options in the same order
as requested resulting in :badmatch.

This fixes the following error:

{{:badmatch, [buffer: 1460, recbuf: 357120, sndbuf: 46080]}, [{Redix.Utils, :setup_socket_buffers, 2, [file: 'lib/redix/utils.ex', line: 123]}, {Redix.Utils, :connect, 1, [file: 'lib/redix/utils.ex', line: 84]}, {Redix.SocketOwner, :handle_info, 2, [file: 'lib/redix/socket_owner.ex', line: 39]}
