### PR TITLE
use app get_env when start_link is given no options

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure for your application as:
+#
+#     config :redix, key: :value
+#
+# And access this configuration in your application as:
+#
+#     Application.get_env(:redix, :key)
+#
+# Or configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -199,6 +199,14 @@ defmodule Redix do
   @spec start_link(binary() | keyword()) :: :gen_statem.start_ret()
   def start_link(uri_or_opts \\ [])
 
+  def start_link([]),
+    do:
+      [
+        host: Application.get_env(:redix, :host, "localhost"),
+        port: Application.get_env(:redix, :port, 6379)
+      ]
+      |> start_link()
+
   def start_link(uri) when is_binary(uri), do: start_link(uri, [])
   def start_link(opts) when is_list(opts), do: Redix.Connection.start_link(opts)
 


### PR DESCRIPTION
This allows setting up redix from application environment.

I only set the options I know about / need. Maybe there are more you'd like me to support?