### PR TITLE
Start using Telemetry

### DIFF
--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -153,7 +153,7 @@ defmodule Redix.Connection do
   # the socket owner to die so that it can finish processing the data it's processing. When it's
   # dead, we go ahead and notify the remaining clients, setup backoff, and so on.
   def disconnected(:info, {:stopped, owner, reason}, %__MODULE__{socket_owner: owner} = data) do
-    Telemetry.execute(:disconnected, data.opts[:log], %{
+    Telemetry.execute(:disconnection, data.opts[:log], %{
       address: data.connected_address,
       reason: %ConnectionError{reason: reason}
     })
@@ -227,7 +227,7 @@ defmodule Redix.Connection do
   def connected(:info, {:stopped, owner, reason}, %__MODULE__{socket_owner: owner} = data) do
     Telemetry.execute(:disconnection, data.opts[:log], %{
       address: data.connected_address,
-      reason: reason
+      reason: %ConnectionError{reason: reason}
     })
 
     data = %{data | connected_address: nil}

--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -3,8 +3,6 @@ defmodule Redix.Connection do
 
   alias Redix.{ConnectionError, Protocol, SocketOwner, StartOptions, Telemetry}
 
-  require Logger
-
   @behaviour :gen_statem
 
   defstruct [
@@ -153,7 +151,7 @@ defmodule Redix.Connection do
   # the socket owner to die so that it can finish processing the data it's processing. When it's
   # dead, we go ahead and notify the remaining clients, setup backoff, and so on.
   def disconnected(:info, {:stopped, owner, reason}, %__MODULE__{socket_owner: owner} = data) do
-    Telemetry.execute(:disconnection, data.opts[:log], %{
+    Telemetry.execute(:disconnection, %{
       address: data.connected_address,
       reason: %ConnectionError{reason: reason}
     })
@@ -168,7 +166,7 @@ defmodule Redix.Connection do
         %__MODULE__{socket_owner: owner} = data
       ) do
     if data.backoff_current do
-      Telemetry.execute(:reconnected, data.opts[:log], %{address: address})
+      Telemetry.execute(:reconnected, %{address: address})
     end
 
     data = %{data | socket: socket, backoff_current: nil, connected_address: address}
@@ -181,7 +179,7 @@ defmodule Redix.Connection do
 
   def connecting(:info, {:stopped, owner, reason}, %__MODULE__{socket_owner: owner} = data) do
     # We log this when the socket owner stopped while connecting.
-    Telemetry.execute(:failed_connection, data.opts[:log], %{
+    Telemetry.execute(:failed_connection, %{
       address: format_address(data),
       reason: %ConnectionError{reason: reason}
     })
@@ -225,7 +223,7 @@ defmodule Redix.Connection do
   end
 
   def connected(:info, {:stopped, owner, reason}, %__MODULE__{socket_owner: owner} = data) do
-    Telemetry.execute(:disconnection, data.opts[:log], %{
+    Telemetry.execute(:disconnection, %{
       address: data.connected_address,
       reason: %ConnectionError{reason: reason}
     })

--- a/lib/redix/pubsub.ex
+++ b/lib/redix/pubsub.ex
@@ -265,8 +265,9 @@ defmodule Redix.PubSub do
       will be ignored. Defaults to `false`.
 
     * `:log` - (keyword list) a keyword list of `{action, level}` where `level` is
-      the log level to use to log `action`. The possible actions and their default
-      values are:
+      the log level to use to log `action`. **This option is deprecated** in favor
+      of Telemetry. See the "Telemetry" section in the module documentation.
+      The possible actions and their default values are:
         * `:disconnection` (defaults to `:error`) - logged when the connection to
           Redis is lost
         * `:failed_connection` (defaults to `:error`) - logged when Redix can't

--- a/lib/redix/pubsub/connection.ex
+++ b/lib/redix/pubsub/connection.ex
@@ -5,8 +5,6 @@ defmodule Redix.PubSub.Connection do
 
   alias Redix.{ConnectionError, Connector, Protocol, Telemetry}
 
-  require Logger
-
   defstruct [
     :opts,
     :transport,
@@ -68,7 +66,7 @@ defmodule Redix.PubSub.Connection do
   end
 
   def disconnected(:internal, :handle_disconnection, data) do
-    Telemetry.execute(:disconnection, data.opts[:log], %{
+    Telemetry.execute(:disconnection, %{
       address: data.connected_address,
       reason: data.last_disconnect_reason
     })
@@ -107,7 +105,7 @@ defmodule Redix.PubSub.Connection do
     with {:ok, socket, address} <- Connector.connect(data.opts),
          :ok <- setopts(data, socket, active: :once) do
       if data.last_disconnect_reason do
-        Telemetry.execute(:reconnected, data.opts[:log], %{address: address})
+        Telemetry.execute(:reconnected, %{address: address})
       end
 
       data = %__MODULE__{
@@ -121,7 +119,7 @@ defmodule Redix.PubSub.Connection do
       {:next_state, :connected, data, {:next_event, :internal, :handle_connection}}
     else
       {:error, reason} ->
-        Telemetry.execute(:failed_connection, data.opts[:log], %{
+        Telemetry.execute(:failed_connection, %{
           address: format_address(data),
           reason: %ConnectionError{reason: reason}
         })

--- a/lib/redix/pubsub/connection.ex
+++ b/lib/redix/pubsub/connection.ex
@@ -3,7 +3,7 @@ defmodule Redix.PubSub.Connection do
 
   @behaviour :gen_statem
 
-  alias Redix.{ConnectionError, Connector, Protocol}
+  alias Redix.{ConnectionError, Connector, Protocol, Telemetry}
 
   require Logger
 
@@ -68,10 +68,10 @@ defmodule Redix.PubSub.Connection do
   end
 
   def disconnected(:internal, :handle_disconnection, data) do
-    log(data, :disconnection, fn ->
-      "Disconnected from Redis (#{data.connected_address}): " <>
-        Exception.message(data.last_disconnect_reason)
-    end)
+    Telemetry.execute(:disconnection, data.opts[:log], %{
+      address: data.connected_address,
+      reason: data.last_disconnect_reason
+    })
 
     if data.opts[:exit_on_disconnection] do
       {:stop, data.last_disconnect_reason}
@@ -107,7 +107,7 @@ defmodule Redix.PubSub.Connection do
     with {:ok, socket, address} <- Connector.connect(data.opts),
          :ok <- setopts(data, socket, active: :once) do
       if data.last_disconnect_reason do
-        log(data, :reconnection, fn -> "Reconnected to Redis (#{address})" end)
+        Telemetry.execute(:reconnected, data.opts[:log], %{address: address})
       end
 
       data = %__MODULE__{
@@ -121,10 +121,10 @@ defmodule Redix.PubSub.Connection do
       {:next_state, :connected, data, {:next_event, :internal, :handle_connection}}
     else
       {:error, reason} ->
-        log(data, :failed_connection, fn ->
-          "Failed to connect to Redis (#{format_address(data)}): " <>
-            Exception.message(%ConnectionError{reason: reason})
-        end)
+        Telemetry.execute(:failed_connection, data.opts[:log], %{
+          address: format_address(data),
+          reason: %ConnectionError{reason: reason}
+        })
 
         disconnect(data, reason, _handle_disconnection? = false)
 
@@ -600,15 +600,6 @@ defmodule Redix.PubSub.Connection do
   defp send(pid, ref, kind, properties)
        when is_pid(pid) and is_reference(ref) and is_atom(kind) and is_map(properties) do
     send(pid, {:redix_pubsub, self(), ref, kind, properties})
-  end
-
-  defp log(data, action, message) do
-    level =
-      data.opts
-      |> Keyword.fetch!(:log)
-      |> Keyword.fetch!(action)
-
-    Logger.log(level, message)
   end
 
   defp format_address(%{opts: opts} = _state) do

--- a/lib/redix/telemetry.ex
+++ b/lib/redix/telemetry.ex
@@ -35,7 +35,7 @@ defmodule Redix.Telemetry do
           "Failed to connect to Redis (#{metadata.address}): #{human_reason}"
 
         :disconnection ->
-          human_reason = Exception.message(reason: metadata.reason)
+          human_reason = Exception.message(metadata.reason)
           "Disconnected from Redis (#{metadata.address}): #{human_reason}"
 
         :reconnection ->

--- a/lib/redix/telemetry.ex
+++ b/lib/redix/telemetry.ex
@@ -10,9 +10,7 @@ defmodule Redix.Telemetry do
       [:redix, :failed_connection]
     ]
 
-    # Avoid warnings if :telemetry is not available.
-    telemetry = :telemetry
-    telemetry.attach_many("redix-default-telemetry-handler", events, &handle_event/4, :no_config)
+    :telemetry.attach_many("redix-default-telemetry-handler", events, &handle_event/4, :no_config)
   end
 
   def handle_event([:redix, event], _measurements, metadata, :no_config)
@@ -37,20 +35,8 @@ defmodule Redix.Telemetry do
     end
   end
 
-  @spec execute(atom(), map()) :: :ok
-  def execute(event, metadata) do
+  def execute(event, metadata) when is_atom(event) and is_map(metadata) do
     metadata = Map.put(metadata, :connection, self())
-    :ok = telemetry_execute(event, metadata)
-  end
-
-  # TODO: remove this once we depend not optionally on Telemetry.
-  if Code.ensure_compiled?(:telemetry) do
-    defp telemetry_execute(event, metadata) do
-      :ok = :telemetry.execute([:redix, event], _measurements = %{}, metadata)
-    end
-  else
-    defp telemetry_execute(_event, _metadata) do
-      :ok
-    end
+    :ok = :telemetry.execute([:redix, event], _measurements = %{}, metadata)
   end
 end

--- a/lib/redix/telemetry.ex
+++ b/lib/redix/telemetry.ex
@@ -1,0 +1,65 @@
+defmodule Redix.Telemetry do
+  @moduledoc false
+
+  require Logger
+
+  @default_log_options [
+    disconnection: :error,
+    failed_connection: :error,
+    reconnection: :info
+  ]
+
+  def attach_default_handler() do
+    events = [
+      [:redix, :disconnection],
+      [:redix, :reconnection],
+      [:redix, :failed_connection]
+    ]
+
+    # Avoid warnings if :telemetry is not available.
+    telemetry = :telemetry
+    telemetry.attach_many("redix-default-telemetry-handler", events, &handle_event/4, :no_config)
+  end
+
+  def handle_event([:redix, event], _measurements, metadata, :no_config) do
+    handle_event_with_log_opts(event, metadata, @default_log_options)
+  end
+
+  defp handle_event_with_log_opts(event, metadata, log_opts) do
+    level = Keyword.fetch!(log_opts, event)
+
+    message =
+      case event do
+        :failed_connection ->
+          human_reason = Exception.message(metadata.reason)
+          "Failed to connect to Redis (#{metadata.address}): #{human_reason}"
+
+        :disconnection ->
+          human_reason = Exception.message(reason: metadata.reason)
+          "Disconnected from Redis (#{metadata.address}): #{human_reason}"
+
+        :reconnection ->
+          "Reconnected to Redis (#{metadata.address})"
+      end
+
+    :ok = Logger.log(level, message)
+  end
+
+  @spec execute(keyword(), atom(), map()) :: :ok
+  def execute(event, log_opts, metadata) do
+    metadata = Map.put(metadata, :connection, self())
+    telemetry_execute(event, log_opts, metadata)
+  end
+
+  if Code.ensure_compiled?(:telemetry) do
+    defp telemetry_execute(event, _log_opts, metadata) do
+      :ok = :telemetry.execute([:redix, event], _measurements = %{}, metadata)
+    end
+  else
+    # This approach is deprecated. We show the deprecation if users specifically
+    # pass the :log option to start_link/1,2.
+    defp telemetry_execute(event, log_opts, metadata) do
+      :ok = handle_event_with_log_opts(event, metadata, log_opts)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule Redix.Mixfile do
           "README.md",
           "pages/Reconnections.md",
           "pages/Real-world usage.md",
+          "pages/Telemetry.md",
           "CHANGELOG.md"
         ]
       ]
@@ -50,6 +51,7 @@ defmodule Redix.Mixfile do
 
   defp deps() do
     [
+      {:telemetry, "~> 0.4.0"},
       {:ex_doc, "~> 0.19", only: :dev},
       {:stream_data, "~> 0.4", only: :test},
       {:propcheck, "~> 1.1", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -7,4 +7,5 @@
   "propcheck": {:hex, :propcheck, "1.1.4", "95852a3f050cc3ee1ef5c9ade14a3bd34e29b54cb8db7ae8bc7f716d904d5120", [:mix], [{:proper, "~> 1.3", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
   "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.1", "bcdb74204ff3eb45d0db87b78337b3b7045472032dad2272506eb3ecd056a6ae", [:mix], []},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }

--- a/pages/Telemetry.md
+++ b/pages/Telemetry.md
@@ -1,0 +1,88 @@
+# Telemetry
+
+Since version v0.10.0, Redix uses [Telemetry][telemetry] for instrumentation and for having an extensible way of doing logging. Telemetry is a metrics and instrumentation library for Erlang and Elixir applications that is based on publishing events through a common interface and attaching handlers to handle those events. For more information about the library itself, see [its README][telemetry].
+
+Telemetry is an optional dependency for Redix, so if you want to use it, add it explicitly to your dependencies:
+
+    defp deps do
+      [
+        # ...
+        {:redix, ">= 0.0.0"},
+        {:telemetry, ">= 0.0.0"}
+      ]
+
+Before version v0.10.0, `Redix.start_link/1` and `Redix.PubSub.start_link/1` supported a `:log` option to control logging. For example, if you wanted to log disconnections at the `:error` level and reconnections and the `:debug` level, you would do:
+
+    Redix.start_link(log: [disconnection: :error, reconnection: :debug])
+
+The `:log` option is now deprecated in favour of either using the default Redix event handler or writing your own. See below for more information.
+
+## Events
+
+Redix connections (both `Redix` and `Redix.PubSub`) execute the following Telemetry events:
+
+  * `[:redix, :disconnection]` - executed when the connection is lost with the Redis server. There are no measurements associated with this event. Metadata are:
+
+    * `:reason` - the disconnection reason as a `Redix.ConnectionError` struct.
+    * `:address` - the address the connection was connected to.
+
+  * `[:redix, :failed_connection]` - executed when Redix can't connect to the specified Redis server, either when starting up the connection or after a disconnection. There are no measurements associated with this event. Metadata are:
+
+    * `:reason` - the disconnection reason as a `Redix.ConnectionError` struct.
+    * `:address` - the address the connection was connected to.
+
+  * `[:redix, :reconnection]` - executed when a Redix connection that had disconnected reconnects to a Redis server. There are no measurements associated with this event. Metadata are:
+
+    * `:address` - the address the connection successfully reconnected to.
+
+More events might be added in the future and that won't be considered a breaking change, so if you're writing a handler for Redix events be sure to ignore events that are not known. All future Redix events will start with the `:redix` atom, like the ones above.
+
+## Default handler for logging
+
+If you want a quick solution to log Redix events, call `Redix.attach_default_telemetry_handler/0` when starting your application. This will attach a default handler for Redix events that logs them at the following levels:
+
+  * `[:redix, :disconnection]` and `[:redix, :failed_connection]` are logged at the `:error` level.
+
+  * `[:redix, :reconnection]` is logged at the `:info` level.
+
+These are reasonable defaults that work for most applications. The default event handler does not support customizing the log levels with a `:log` option like it's possible today. If you want more control over how these events are logged, you have to write your own event handler, see below.
+
+## Writing your own handler
+
+If you want control on how Redix events are logged or on what level they're logged at, you can use your own event handler. For example, you can create a module to handle these events:
+
+    defmodule MyApp.RedixTelemetryHandler do
+      require Logger
+
+      def handle_event([:redix, event], _measurements, metadata, _config) do
+        case event do
+          :disconnection ->
+            human_reason = Exception.message(metadata.reason)
+            Logger.warn("Disconnected from #{metadata.address}: #{human_reason}")
+            
+          :failed_connection ->
+            human_reason = Exception.message(metadata.reason)
+            Logger.warn("Failed to connect to #{metadata.address}: #{human_reason}")
+
+          :reconnection ->
+            Logger.debug("Reconnected to #{metadata.address}")
+        end
+      end
+    end
+
+Once you have a module like this, you can attach it when your application starts:
+
+    events = [
+      [:redix, :disconnection],
+      [:redix, :failed_connection],
+      [:redix, :reconnection]
+    ]
+
+    :telemetry.attach_many(
+      "my-redix-log-handler",
+      events,
+      &MyApp.RedixTelemetryHandler.handle_event/4,
+      :config_not_needed_here
+    )
+
+[telemetry]: https://github.com/beam-telemetry/telemetry

--- a/pages/Telemetry.md
+++ b/pages/Telemetry.md
@@ -25,15 +25,18 @@ Redix connections (both `Redix` and `Redix.PubSub`) execute the following Teleme
 
     * `:reason` - the disconnection reason as a `Redix.ConnectionError` struct.
     * `:address` - the address the connection was connected to.
+    * `:conn` - the PID of the Redix connection that emitted the event.
 
   * `[:redix, :failed_connection]` - executed when Redix can't connect to the specified Redis server, either when starting up the connection or after a disconnection. There are no measurements associated with this event. Metadata are:
 
     * `:reason` - the disconnection reason as a `Redix.ConnectionError` struct.
     * `:address` or `:sentinel_address` - the address the connection was trying to connect to (either a Redis server or a Redis Sentinel instance).
+    * `:conn` - the PID of the Redix connection that emitted the event.
 
   * `[:redix, :reconnection]` - executed when a Redix connection that had disconnected reconnects to a Redis server. There are no measurements associated with this event. Metadata are:
 
     * `:address` - the address the connection successfully reconnected to.
+    * `:conn` - the PID of the Redix connection that emitted the event.
 
 More events might be added in the future and that won't be considered a breaking change, so if you're writing a handler for Redix events be sure to ignore events that are not known. All future Redix events will start with the `:redix` atom, like the ones above.
 

--- a/pages/Telemetry.md
+++ b/pages/Telemetry.md
@@ -29,7 +29,7 @@ Redix connections (both `Redix` and `Redix.PubSub`) execute the following Teleme
   * `[:redix, :failed_connection]` - executed when Redix can't connect to the specified Redis server, either when starting up the connection or after a disconnection. There are no measurements associated with this event. Metadata are:
 
     * `:reason` - the disconnection reason as a `Redix.ConnectionError` struct.
-    * `:address` - the address the connection was connected to.
+    * `:address` or `:sentinel_address` - the address the connection was trying to connect to (either a Redis server or a Redis Sentinel instance).
 
   * `[:redix, :reconnection]` - executed when a Redix connection that had disconnected reconnects to a Redis server. There are no measurements associated with this event. Metadata are:
 
@@ -39,13 +39,15 @@ More events might be added in the future and that won't be considered a breaking
 
 ## Default handler for logging
 
-If you want a quick solution to log Redix events, call `Redix.attach_default_telemetry_handler/0` when starting your application. This will attach a default handler for Redix events that logs them at the following levels:
+By default, Redix provides a Telemetry event handler that performs logging. Events will be logged as follows:
 
   * `[:redix, :disconnection]` and `[:redix, :failed_connection]` are logged at the `:error` level.
 
   * `[:redix, :reconnection]` is logged at the `:info` level.
 
-These are reasonable defaults that work for most applications. The default event handler does not support customizing the log levels with a `:log` option like it's possible today. If you want more control over how these events are logged, you have to write your own event handler, see below.
+These are reasonable defaults that work for most applications. The default event handler does not support customizing the log levels. To use this default log handler, call this when starting your application:
+
+    Redix.attach_default_telemetry_handler()
 
 ## Writing your own handler
 

--- a/test/redix/stateful_properties/pubsub_properties_test.exs
+++ b/test/redix/stateful_properties/pubsub_properties_test.exs
@@ -12,8 +12,7 @@ defmodule Redix.PubSubPropertiesTest do
   defmodule PubSub do
     @opts [
       name: __MODULE__,
-      backoff_initial: 0,
-      log: [disconnection: :debug, reconnection: :debug]
+      backoff_initial: 0
     ]
 
     def start_link(), do: Redix.PubSub.start_link(@opts)


### PR DESCRIPTION
\cc @josevalim and @arkgil, mentioning both of you as kindly offered by José :)

Related to #127.

The gist here is:

  * we publish disconnection/reconnection events to Telemetry, with no measurements and metadata about the connection and the disconnection reason.
  * we provide `Redix.attach_default_telemetry_handler/0` to attach a default handler that logs the events.
  * we don't require Telemetry just yet. We'll keep supporting the current API at least for the next version.

Wdyt about the event naming and the usage in general?