### PR TITLE
Al/telemetry events for pipeline

### DIFF
--- a/pages/Telemetry.md
+++ b/pages/Telemetry.md
@@ -42,17 +42,19 @@ Redix connections (both `Redix` and `Redix.PubSub`) execute the following Teleme
 
   * `[:redix, :pipeline]` - executed when a pipeline (or command, which is a pipeline with just one command) is successfully sent to the server and a reply comes from the server. Measurements are:
 
-    * `:elapsed_time` (integer) - the elapsed time in microseconds that it took to send the pipeline to the server and get a reply.
+    * `:elapsed_time` (integer) - the elapsed time that it took to send the pipeline to the server and get a reply. The elapsed time is expressed in the `:native` time unit. See `System.convert_time_unit/3`.
 
     Metadata are:
 
       * `:connection` - the connection that emitted the event. If the connection was registered with a name, the name is used here, otherwise the PID.
       * `:commands` - the commands sent to the server. This is always a list of commands, so even if you do `Redix.command(conn, ["PING"])` than the list of commands will be `[["PING"]]`.
+      * `:start_time` - the system time when the pipeline was issued. This could be useful for tracing. The time unit is `:native`, see `System.convert_time_unit/3`.
 
-  * `[:redix, :error]` - executed when there's an error talking to the server. There are no measurements. Metadata are:
+  * `[:redix, :pipeline, :error]` - executed when there's an error talking to the server. There are no measurements. Metadata are:
 
       * `:connection` - the connection that emitted the event. If the connection was registered with a name, the name is used here, otherwise the PID.
       * `:commands` - the commands sent to the server. This is always a list of commands, so even if you do `Redix.command(conn, ["PING"])` than the list of commands will be `[["PING"]]`.
+      * `:start_time` - the system time when the pipeline was issued. This could be useful for tracing. The time unit is `:native`, see `System.convert_time_unit/3`.
       * `:reason` - the error reason.
 
 More events might be added in the future and that won't be considered a breaking change, so if you're writing a handler for Redix events be sure to ignore events that are not known. All future Redix events will start with the `:redix` atom, like the ones above.

--- a/pages/Telemetry.md
+++ b/pages/Telemetry.md
@@ -38,6 +38,23 @@ Redix connections (both `Redix` and `Redix.PubSub`) execute the following Teleme
     * `:address` - the address the connection successfully reconnected to.
     * `:conn` - the PID of the Redix connection that emitted the event.
 
+`Redix` connections execute the following Telemetry events when commands or pipelines of any kind are executed.
+
+  * `[:redix, :pipeline]` - executed when a pipeline (or command, which is a pipeline with just one command) is successfully sent to the server and a reply comes from the server. Measurements are:
+
+    * `:elapsed_time` (integer) - the elapsed time in microseconds that it took to send the pipeline to the server and get a reply.
+
+    Metadata are:
+
+      * `:connection` - the connection that emitted the event. If the connection was registered with a name, the name is used here, otherwise the PID.
+      * `:commands` - the commands sent to the server. This is always a list of commands, so even if you do `Redix.command(conn, ["PING"])` than the list of commands will be `[["PING"]]`.
+
+  * `[:redix, :error]` - executed when there's an error talking to the server. There are no measurements. Metadata are:
+
+      * `:connection` - the connection that emitted the event. If the connection was registered with a name, the name is used here, otherwise the PID.
+      * `:commands` - the commands sent to the server. This is always a list of commands, so even if you do `Redix.command(conn, ["PING"])` than the list of commands will be `[["PING"]]`.
+      * `:reason` - the error reason.
+
 More events might be added in the future and that won't be considered a breaking change, so if you're writing a handler for Redix events be sure to ignore events that are not known. All future Redix events will start with the `:redix` atom, like the ones above.
 
 ## Default handler for logging


### PR DESCRIPTION
\cc @binaryseed @deadtrickster @arkgil @josevalim, pinging all of you since you gave great feedback on the last PR. This PR adds tracing to commands sent to Redis.

I'm looking for feedback on:

  * the separation between the `[:redix, :pipeline]` and `[:redix, :error]` events. I did this because if we have a single event with a `success?` meta field and an elapsed time measurements, then errors like `:disconnected` are gonna screw up measurements since their elapsed time will be very short as there's no talking with the database.

  * putting the whole list of commands in the metadata. I'm doing this so users can figure out how to group them, by count or type or whatever.

Thoughts?