### PR TITLE
Secure ssl socket defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This README refers to the `master` branch of Redix, not the latest released vers
 
 ## Installation
 
-Add the `:redix` dependency to your `mix.exs` file. If you plan on connecting to a Redis server [over SSL][docs-ssl] you may want to add the optional `:castore` dependency as well:
+Add the `:redix` dependency to your `mix.exs` file. If you plan on connecting to a Redis server [over SSL][docs-ssl] you may want to add the optional [`:castore`][castore] dependency as well:
 
 ```elixir
 defp deps() do
@@ -145,6 +145,7 @@ Redix is released under the MIT license. See the [license file](LICENSE.txt).
 [redis]: http://redis.io
 [redis-sentinel]: https://redis.io/topics/sentinel
 [redix-pubsub]: https://github.com/whatyouhide/redix_pubsub
+[castore]: https://github.com/ericmj/castore
 [docs-ssl]: https://hexdocs.pm/redix/Redix.html#module-ssl
 [docs-reconnections]: http://hexdocs.pm/redix/reconnections.html
 [docs-real-world-usage]: http://hexdocs.pm/redix/real-world-usage.html

--- a/README.md
+++ b/README.md
@@ -22,15 +22,18 @@ This README refers to the `master` branch of Redix, not the latest released vers
 
 ## Installation
 
-Add the `:redix` dependency to your `mix.exs` file:
+Add the `:redix` dependency to your `mix.exs` file. If you plan on connecting to a Redis server [over SSL][docs-ssl] you may want to add the optional `:castore` dependency as well:
 
 ```elixir
 defp deps() do
-  [{:redix, ">= 0.0.0"}]
+  [
+    {:redix, ">= 0.0.0"},
+    {:castore, ">= 0.0.0"}
+  ]
 end
 ```
 
-Then, run `mix deps.get` in your shell to fetch the new dependency.
+Then, run `mix deps.get` in your shell to fetch the new dependencies.
 
 ## Usage
 
@@ -142,6 +145,7 @@ Redix is released under the MIT license. See the [license file](LICENSE.txt).
 [redis]: http://redis.io
 [redis-sentinel]: https://redis.io/topics/sentinel
 [redix-pubsub]: https://github.com/whatyouhide/redix_pubsub
+[docs-ssl]: https://hexdocs.pm/redix/Redix.html#module-ssl
 [docs-reconnections]: http://hexdocs.pm/redix/reconnections.html
 [docs-real-world-usage]: http://hexdocs.pm/redix/real-world-usage.html
 [docker]: https://www.docker.com

--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -81,7 +81,7 @@ defmodule Redix do
   If the [CAStore](https://hex.pm/packages/castore) dependency is available, Redix will pick
   up its CA certificate store file automatically. You can select a different CA certificate
   store by passing in the `:cacertfile` or `:cacerts` socket options. If the server uses a
-  self-signed certificate, e.g. for testing purposes, disable certificate verification by
+  self-signed certificate, such as for testing purposes, disable certificate verification by
   passing `verify: :verify_none` in the socket options.
 
   Some Redis servers, notably Amazon ElastiCache, use wildcard certificates that require

--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -84,9 +84,8 @@ defmodule Redix do
   self-signed certificate, e.g. for testing purposes, disable certificate verification by
   passing `verify: :verify_none` in the socket options.
 
-  Some Redis servers, notably Amazon ElastiCache, use a wildcard certificates that require
-  additional socket options to be set for succesful verification (requires OTP 21.0 or
-  later):
+  Some Redis servers, notably Amazon ElastiCache, use wildcard certificates that require
+  additional socket options for succesful verification (requires OTP 21.0 or later):
 
       Redix.start_link(
         host: "example.com", port: 9999, ssl: true,

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,7 @@ defmodule Redix.Mixfile do
   defp deps() do
     [
       {:telemetry, "~> 0.4.0"},
+      {:castore, "~> 0.1.0", optional: true},
       {:ex_doc, "~> 0.19", only: :dev},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev},
       {:stream_data, "~> 0.4", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "castore": {:hex, :castore, "0.1.2", "81adb0683c4ec8ebb97ad777ec1b050405282d55453df14567a3c73ae25932a6", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},


### PR DESCRIPTION
* Default to `verify: :verify_peer` to enable server certificate verification
* Default to `depth: 2` for better interoperability
* If CAStore is available (optional dependency), select its CA certificate file by default
* Documentation includes instructions for enabling wildcard certificate support, e.g. for Amazon ElastiCache

**Breaking changes**:
* Connection to servers with untrusted (e.g. self-signed) certificate will now *fail* by default; add `verify: :verify_none` to the `:socket_opts` or (preferably) get a trusted certificate
* Connection to servers with a valid certificate will now *fail* by default if CAStore is not available; add CAStore dependency, pass a custom `:cacertfile` in `:socket_opts` or select `verify: :verify_none` (if you must)

Includes basic tests with Redis Docker image, which has an untrusted certificate. Further positive and negative testing, including with valid certificates, would require adding X509 as a test dependency and a Redis mock server.

Manually tested against various https://baddssl.com/ endpoints (TLS handshake only, obviously).