### PR TITLE
Fix Redix.child_spec/1

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -353,8 +353,12 @@ defmodule Redix do
     child_spec_with_args([uri, opts])
   end
 
-  def child_spec(uri_or_opts) when is_binary(uri_or_opts) or is_list(uri_or_opts) do
-    child_spec_with_args([uri_or_opts])
+  def child_spec(uri) when is_binary(uri) do
+    child_spec_with_args([uri])
+  end
+
+  def child_spec(opts) when is_list(opts) do
+    child_spec_with_args(opts)
   end
 
   defp child_spec_with_args(args) do

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -120,8 +120,8 @@ defmodule RedixTest do
     assert Redix.child_spec("redis://localhost") ==
              put_in(default_spec, args_path, ["redis://localhost"])
 
-    assert Redix.child_spec([]) == put_in(default_spec, args_path, [[]])
-    assert Redix.child_spec(name: :redix) == put_in(default_spec, args_path, [[name: :redix]])
+    assert Redix.child_spec([]) == put_in(default_spec, args_path, [])
+    assert Redix.child_spec(name: :redix) == put_in(default_spec, args_path, name: :redix)
 
     assert Redix.child_spec({"redis://localhost", name: :redix}) ==
              put_in(default_spec, args_path, ["redis://localhost", [name: :redix]])


### PR DESCRIPTION
  - Fix case when using keyword opts instead of `{uri, opts}`
  - Poolboy expects worker argument to be `[]`, not `[[]]`
  - This matches better with what is in the documentation for
child_spec/1

Main motivations for this fix:
  - Need to be able to add child_spec directly into the supervision tree, or to Poolboy's spec generator
  - Need to be able convert the uri into keyword opts, transform it, and then pass it into child_spec 