### PR TITLE
Add sentinel support for older versions of Redis

### DIFF
--- a/lib/redix/connector.ex
+++ b/lib/redix/connector.ex
@@ -162,7 +162,22 @@ defmodule Redix.Connector do
     case sync_command(transport, server_socket, ["ROLE"], timeout) do
       {:ok, [^expected_role | _]} -> :ok
       {:ok, [role | _]} -> {:error, {:wrong_role, role}}
+      {:error, %Redix.Error{message: "ERR unknown command 'ROLE'"}} ->
+        verify_with_info_command(transport, server_socket, timeout, expected_role)
       {:error, _reason_or_redis_error} = error -> error
+    end
+  end
+
+  # The ROLE command was introduced in Redis 2.8.12 - for older versions we can
+  # get the same information by calling "INFO replication" and pulling the role
+  # attribute from the result.
+  defp verify_with_info_command(transport, server_socket, timeout, expected_role) do
+    with {:ok, resp} <- sync_command(transport, server_socket, ["INFO", "replication"], timeout) do
+      case pluck_role_from_info_response(resp) do
+        {:ok, ^expected_role} -> :ok
+        {:ok, role} -> {:error, {:wrong_role, role}}
+        {:error, _reason} = error -> error
+      end
     end
   end
 
@@ -213,5 +228,24 @@ defmodule Redix.Connector do
         {:continuation, continuation} -> recv_response(transport, socket, continuation, timeout)
       end
     end
+  end
+
+  # Parses the response from an 'INFO replication' command and returns the value
+  # of the "role" attribute
+  defp pluck_role_from_info_response(resp) do
+    newline = ~r{(\r\n|\r|\n)}
+
+    resp
+    # Trim any leading or trailing whitespace
+    |> String.trim()
+    # Split the response on newlines
+    |> String.split(newline)
+    # Split each line on ":"
+    |> Enum.map(&String.split(&1, ":"))
+    # Only keep lists (line) with two elements (key & value)
+    |> Enum.filter(fn t -> length(t) == 2 end)
+    # Turn the list of 2 element lists into a map
+    |> Map.new(fn [k, v] -> {k, v} end)
+    |> Map.fetch("role")
   end
 end


### PR DESCRIPTION
## Fun backstory

When I met @whatyouhide in Prague during the ElixirConfEU speakers dinner and I told him I loved `Redix` he asked if I used Sentinel. I said, yes, but in conjunction with [redix_sentinel](https://github.com/ananthakumaran/redix_sentinel). He said, "you should upgrade your Redix, we now support sentinel." 🎉 

Flash forward 7 months and I'm finally upgrading my Redix version so I can drop the redix_sentinel dependency...and I run into the same issue I had with redix_sentinel (that I forgot to mention in our conversation). And the problem isn't with the library so much as it is with my project being stuck on a really old version of Redis (😢).

## This PR

The crux of the problem I'm running into is this:

As part of connecting to a sentinel, we need to verify that the server we are told is the primary actually thinks it is the primary. This is usually done via the `ROLE` command.

Unfortunately (for me), the `ROLE` command was introduced in version 2.8.12 so when Redix attempts to verify the role of the primary, it gets an error saying the server doesn't understand `ROLE`.

According to [the Redis docs](https://redis.io/topics/sentinel-clients#step-3-call-the-role-command-in-the-target-instance): 
>If the ROLE commands is not available (it was introduced in Redis 2.8.12), a client may resort to the INFO replication command parsing the role: field of the output.

And this ^^ is what this PR does.

For more context, [I added "old sentinel" support to redix_sentinel](https://github.com/ananthakumaran/redix_sentinel/pull/3) back in May 2018 and have been using it in production ever since with no issues.

Also, I kind of just plopped this code in a place that I thought made sense based on my limited knowledge of the Redix internals, so let me know if it should be somewhere else.