### PR TITLE
Fix default option replacement for OTP 22.2

### DIFF
--- a/lib/redix/connector.ex
+++ b/lib/redix/connector.ex
@@ -190,6 +190,7 @@ defmodule Redix.Connector do
       else
         @default_ssl_opts
       end
+      |> Enum.reject(fn {key, _val} -> Keyword.has_key?(user_socket_opts, key) end)
 
     @socket_opts ++ user_socket_opts ++ default_opts
   end

--- a/lib/redix/connector.ex
+++ b/lib/redix/connector.ex
@@ -190,7 +190,7 @@ defmodule Redix.Connector do
       else
         @default_ssl_opts
       end
-      |> Enum.reject(fn {key, _val} -> Keyword.has_key?(user_socket_opts, key) end)
+      |> Keyword.drop(Keyword.keys(user_socket_opts))
 
     @socket_opts ++ user_socket_opts ++ default_opts
   end


### PR DESCRIPTION
In OTP 22.2 the way `ssl` parses the options changed. Whereas before it would take the first value for a given key, now it takes last. That breaks Redix because the default options are added at the end and always override the user options.

In development we are running a connection with `verify_none` but that option is ignored by OTP 22.2 and we always default to `verify_peer` from Redix. :(

This should fix it - I did see that sometimes the property tests fail but it doesn't seem to have to do with anything I changed. Am I missing something?