### PR TITLE
Adapt to telemetry span exception event name convention

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -808,7 +808,7 @@ defmodule Redix do
           |> Map.put(:kind, :error)
 
         :ok =
-          :telemetry.execute([:redix, :pipeline, :execption], measurements, telemetry_metadata)
+          :telemetry.execute([:redix, :pipeline, :exception], measurements, telemetry_metadata)
 
         {:error, reason}
     end

--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -807,7 +807,9 @@ defmodule Redix do
           |> Map.put(:reason, reason)
           |> Map.put(:kind, :error)
 
-        :ok = :telemetry.execute([:redix, :pipeline, :stop], measurements, telemetry_metadata)
+        :ok =
+          :telemetry.execute([:redix, :pipeline, :execption], measurements, telemetry_metadata)
+
         {:error, reason}
     end
   end

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -565,7 +565,7 @@ defmodule RedixTest do
 
       :telemetry.attach(
         to_string(test_name),
-        [:redix, :pipeline, :execption],
+        [:redix, :pipeline, :exception],
         handler,
         :no_config
       )

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -553,7 +553,7 @@ defmodule RedixTest do
 
       handler = fn event, measurements, meta, _config ->
         if meta.connection == c do
-          assert event == [:redix, :pipeline, :execption]
+          assert event == [:redix, :pipeline, :exception]
           assert is_integer(measurements.duration)
           assert meta.commands == [["PING"], ["PING"]]
           assert meta.kind == :error

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -553,7 +553,7 @@ defmodule RedixTest do
 
       handler = fn event, measurements, meta, _config ->
         if meta.connection == c do
-          assert event == [:redix, :pipeline, :stop]
+          assert event == [:redix, :pipeline, :execption]
           assert is_integer(measurements.duration)
           assert meta.commands == [["PING"], ["PING"]]
           assert meta.kind == :error
@@ -563,7 +563,12 @@ defmodule RedixTest do
         send(parent, ref)
       end
 
-      :telemetry.attach(to_string(test_name), [:redix, :pipeline, :stop], handler, :no_config)
+      :telemetry.attach(
+        to_string(test_name),
+        [:redix, :pipeline, :execption],
+        handler,
+        :no_config
+      )
 
       assert {:error, %ConnectionError{reason: :timeout}} =
                Redix.pipeline(c, [~w(PING), ~w(PING)], timeout: 0)


### PR DESCRIPTION
The `telemetry:span` convention specifies that `:exception` is used in exception cases instead of `:stop` events... This PR simply corrects the event name for exception cases.

* https://github.com/beam-telemetry/telemetry/issues/57

@whatyouhide @keathley @GregMefford @josevalim