### PR TITLE
Revert "Adapt to telemetry span exception event name convention"

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -807,9 +807,7 @@ defmodule Redix do
           |> Map.put(:reason, reason)
           |> Map.put(:kind, :error)
 
-        :ok =
-          :telemetry.execute([:redix, :pipeline, :exception], measurements, telemetry_metadata)
-
+        :ok = :telemetry.execute([:redix, :pipeline, :stop], measurements, telemetry_metadata)
         {:error, reason}
     end
   end

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -553,7 +553,7 @@ defmodule RedixTest do
 
       handler = fn event, measurements, meta, _config ->
         if meta.connection == c do
-          assert event == [:redix, :pipeline, :exception]
+          assert event == [:redix, :pipeline, :stop]
           assert is_integer(measurements.duration)
           assert meta.commands == [["PING"], ["PING"]]
           assert meta.kind == :error
@@ -563,12 +563,7 @@ defmodule RedixTest do
         send(parent, ref)
       end
 
-      :telemetry.attach(
-        to_string(test_name),
-        [:redix, :pipeline, :exception],
-        handler,
-        :no_config
-      )
+      :telemetry.attach(to_string(test_name), [:redix, :pipeline, :stop], handler, :no_config)
 
       assert {:error, %ConnectionError{reason: :timeout}} =
                Redix.pipeline(c, [~w(PING), ~w(PING)], timeout: 0)


### PR DESCRIPTION
Reverts whatyouhide/redix#167.