### PR TITLE
Add support for the :telemetry_extra option at startup

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -237,6 +237,11 @@ defmodule Redix do
       `:host` and `:port` option cannot be provided. For the available sentinel options, see the
       "Sentinel options" section below.
 
+    * `:telemetry_extra` - (map) a map of extra metadata. The value of this option is used
+      in connection-specific Telemetry events (like `[:redix, :connection]`). The value of
+      this option is provided under the `:extra` key in the event metadata. See
+      `Redix.Telemetry`.
+
     * `:hibernate_after` - (integer) if present, the Redix connection process awaits any
       message for the given number of milliseconds and if no message is received, the process
       goes into hibernation automatically (by calling `:proc_lib.hibernate/3`). See

--- a/lib/redix/pubsub.ex
+++ b/lib/redix/pubsub.ex
@@ -285,6 +285,11 @@ defmodule Redix.PubSub do
     * `:sentinel` - (list of options) exactly the same as the `:sentinel` options in
       `Redix.start_link/1`.
 
+    * `:telemetry_extra` - (map) a map of extra metadata. The value of this option is used
+      in connection-specific Telemetry events (like `[:redix, :connection]`). The value of
+      this option is provided under the `:extra` key in the event metadata. See
+      `Redix.Telemetry`.
+
     * `:hibernate_after` - (integer) if present, the Redix connection process awaits any
       message for the given number of milliseconds and if no message is received, the process
       goes into hibernation automatically (by calling `:proc_lib.hibernate/3`). See

--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -15,7 +15,8 @@ defmodule Redix.StartOptions do
     backoff_initial: 500,
     backoff_max: 30000,
     exit_on_disconnection: false,
-    timeout: 5000
+    timeout: 5000,
+    telemetry_extra: %{}
   ]
 
   @allowed_options [

--- a/lib/redix/telemetry.ex
+++ b/lib/redix/telemetry.ex
@@ -5,13 +5,18 @@ defmodule Redix.Telemetry do
   Redix connections (both `Redix` and `Redix.PubSub`) execute the
   following Telemetry events:
 
-    * `[:redix, :connection]` - executed when the connection to Redis
-      is established successfully. There are no measurements associated with
-      this event. Metadata are:
+    * `[:redix, :connection]` - executed when a Redix connection establishes the
+      connection to Redis. There are no measurements associated with this event.
+      Metadata are:
 
-      * `:address` - the address the connection successfully reconnected to.
+      * `:address` - the address the connection successfully connected to.
       * `:connection` - the PID or registered name of the Redix connection
           that emitted the event.
+      * `:reconnection` - a boolean that specifies whether this was a first
+        connection to Redis or a reconnection after a disconnection. This can
+        be useful for more granular logging.
+      * `:extra` - whatever is passed in `:telemetry_extra` when the connection
+        is started.
 
     * `[:redix, :disconnection]` - executed when the connection is lost
       with the Redis server. There are no measurements associated with
@@ -21,6 +26,8 @@ defmodule Redix.Telemetry do
       * `:address` - the address the connection was connected to.
       * `:connection` - the PID or registered name of the Redix connection
         that emitted the event.
+      * `:extra` - whatever is passed in `:telemetry_extra` when the connection
+        is started.
 
     * `[:redix, :failed_connection]` - executed when Redix can't connect to
       the specified Redis server, either when starting up the connection or
@@ -32,17 +39,8 @@ defmodule Redix.Telemetry do
         to connect to (either a Redis server or a Redis Sentinel instance).
       * `:connection` - the PID or registered name of the Redix connection
         that emitted the event.
-
-    * `[:redix, :connection]` - executed when a Redix connection establishes the
-      connection to Redis. There are no measurements associated with this event.
-      Metadata are:
-
-      * `:address` - the address the connection successfully connected to.
-      * `:connection` - the PID or registered name of the Redix connection
-          that emitted the event.
-      * `:reconnection` - a boolean that specifies whether this was a first
-        connection to Redis or a reconnection after a disconnection. This can
-        be useful for more granular logging.
+      * `:extra` - whatever is passed in `:telemetry_extra` when the connection
+        is started.
 
   `Redix` connections execute the following Telemetry events when commands or
   pipelines of any kind are executed.

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -629,7 +629,7 @@ defmodule RedixTest do
 
       :ok = :telemetry.attach(to_string(test_name), [:redix, :connection], handler, :no_config)
 
-      {:ok, _c} = Redix.start_link(name: test_name, telemetry_extra: :some_extra_metadata)
+      {:ok, _c} = Redix.start_link(name: test_name, telemetry_extra: %{foo: :bar})
 
       assert_receive {^ref, :connected, meta}, 1000
 
@@ -637,7 +637,7 @@ defmodule RedixTest do
                address: "localhost:6379",
                connection: test_name,
                reconnection: false,
-               extra: :some_extra_metadata
+               extra: %{foo: :bar}
              }
     end
   end


### PR DESCRIPTION
You can pass `:telemetry_extra` at startup:

```elixir
Redix.start_link(telemetry_extra: %{foo: :bar})
```

These additional metadata will show up in connection-related Telemetry events under the key `:extra`:

```elixir
# For the event [:redix, :connection]
metadata
#=> %{extra: %{foo: :bar}, ...}
```

Partly addresses https://github.com/whatyouhide/redix/issues/166. We still don't have call-specific Telemetry extra.