### PR TITLE
Ensure the continuation is cleared on disconnection in PubSub client

### DIFF
--- a/lib/redix/pubsub/connection.ex
+++ b/lib/redix/pubsub/connection.ex
@@ -588,6 +588,7 @@ defmodule Redix.PubSub.Connection do
 
     data = put_in(data.last_disconnect_reason, %ConnectionError{reason: reason})
     data = put_in(data.socket, nil)
+    data = put_in(data.continuation, nil)
 
     actions = [{{:timeout, :reconnect}, next_backoff, nil}]
 


### PR DESCRIPTION
Closes https://github.com/whatyouhide/redix/issues/174

The test as is exposes more internals than I'd like to but I couldn't think of a better way to reliably test it.

I tried to add bullet proofing to bulk string parsing, as mentioned in https://github.com/whatyouhide/redix/issues/174#issuecomment-620428067 but this broke bulk string parsing property tests. On the other hand, this is not going to be entirely safe because there still can be a corner case of a rogue message getting passed to the continuation that has exact remaining length. It's very unlikely but it may happen. The generator could avoid splits having such property - I couldn't pull this off at the moment though. That aside, clearing continuation on every disconnect should be a surefire way to avoid this issue altogether anyway.