### PR TITLE
Allow password to be nil

### DIFF
--- a/lib/redix/connector.ex
+++ b/lib/redix/connector.ex
@@ -50,6 +50,7 @@ defmodule Redix.Connector do
       case Keyword.fetch(opts, :password) do
         {:ok, {mod, fun, args}} -> apply(mod, fun, args)
         {:ok, password} when is_binary(password) -> password
+        {:ok, nil} -> nil
         :error -> nil
       end
 


### PR DESCRIPTION
Hey all,

I believe, there might be a bug with version 0.11.0 of redix: the [connector.ex](https://github.com/whatyouhide/redix/blob/master/lib/redix/connector.ex#L48) doesn't allow redix password to be `nil`.

Without explicitely accepting `{:ok, nil}`  I get the following error message:
```
[error] GenServer #PID<0.2997.0> terminating
** (CaseClauseError) no case clause matching: {:ok, nil}
    (redix 0.11.0) lib/redix/connector.ex:50: Redix.Connector.maybe_auth/4
    (redix 0.11.0) lib/redix/connector.ex:43: Redix.Connector.auth_and_select/4
    (redix 0.11.0) lib/redix/connector.ex:35: Redix.Connector.connect_directly/3
    (redix 0.11.0) lib/redix/socket_owner.ex:43: Redix.SocketOwner.handle_info/2
    (stdlib 3.12.1) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib 3.12.1) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: :connect
State: %Redix.SocketOwner{conn: #PID<0.2996.0>, continuation: nil, opts: [socket_opts: [], ssl: false, sync_connect: false, backoff_initial: 500, backoff_max: 30000, exit_on_disconnection: false, timeout: 5000, password: nil, name: :redix, host: '127.0.0.1', port: 6379], queue_table: #Reference<0.1690353627.1663172610.73088>, socket: nil, transport: :gen_tcp}
```

After explicitely allowing `nil` as a password value, I can finally proceed without having the error message above.