### PR TITLE
Enhance Redis URI Support

### DIFF
--- a/lib/redix/uri.ex
+++ b/lib/redix/uri.ex
@@ -38,6 +38,8 @@ defmodule Redix.URI do
   end
 
   defp database(%URI{path: "/" <> path = full_path}) do
+    path = path |> String.split("/") |> hd()
+
     case Integer.parse(path) do
       {db, ""} ->
         db

--- a/lib/redix/uri.ex
+++ b/lib/redix/uri.ex
@@ -38,10 +38,8 @@ defmodule Redix.URI do
   end
 
   defp database(%URI{path: "/" <> path = full_path}) do
-    path = path |> String.split("/") |> hd()
-
     case Integer.parse(path) do
-      {db, ""} ->
+      {db, rest} when rest == "" or binary_part(rest, 0, 1) == "/" ->
         db
 
       _other ->

--- a/test/redix/uri_test.exs
+++ b/test/redix/uri_test.exs
@@ -47,10 +47,14 @@ defmodule Redix.URITest do
     assert opts[:host] == "localhost"
     assert is_nil(opts[:database])
 
-    message = "expected database to be an integer, got: \"/2/namespace\""
+    opts = opts_from_uri("redis://localhost/2/namespace")
+    assert opts[:host] == "localhost"
+    assert opts[:database] == 2
+
+    message = "expected database to be an integer, got: \"/peanuts\""
 
     assert_raise ArgumentError, message, fn ->
-      opts_from_uri("redis://localhost/2/namespace")
+      opts_from_uri("redis://localhost/peanuts")
     end
   end
 

--- a/test/redix/uri_test.exs
+++ b/test/redix/uri_test.exs
@@ -56,6 +56,12 @@ defmodule Redix.URITest do
     assert_raise ArgumentError, message, fn ->
       opts_from_uri("redis://localhost/peanuts")
     end
+
+    message = "expected database to be an integer, got: \"/0tacos\""
+
+    assert_raise ArgumentError, message, fn ->
+      opts_from_uri("redis://localhost/0tacos")
+    end
   end
 
   test "opts_from_uri/1: accepts rediss scheme" do


### PR DESCRIPTION
Redis URI support is documented here:

https://www.iana.org/assignments/uri-schemes/prov/redis

In short:

```
Expressed using RFC 5234 ABNF, the "path" grammar production from
  RFC 3986 is overridden as follows:
    path         = [ path-slashed ]
                 ; path is optional
    path-slashed = "/" [ db-number ]
                 ; exactly zero or one path segments
    db-number    = "0" / nz-num
                 ; nonnegative decimal integer with no leading zeros
    nz-num       = NZDIGIT *DIGIT
                 ; positive decimal integer with no leading zeros
    NZDIGIT      = %x31-39
                 ; the digits 1-9
```

Despite this `redis-cli` accepts URIs such as
`redis://localhost/2/cache`. This change supports such URIs.

Resolves #191 