### PR TITLE
Unix socket fixes

### DIFF
--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -395,7 +395,10 @@ defmodule Redix.Connection do
     if opts[:sentinel] do
       "sentinel"
     else
-      "#{opts[:host]}:#{opts[:port]}"
+      case opts[:host] do
+        {:local, path} -> path
+        host -> "#{host}:#{opts[:port]}"
+      end
     end
   end
 end

--- a/lib/redix/connector.ex
+++ b/lib/redix/connector.ex
@@ -33,7 +33,10 @@ defmodule Redix.Connector do
     with {:ok, socket} <- transport.connect(host, port, socket_opts, timeout),
          :ok <- setup_socket_buffers(transport, socket) do
       case auth_and_select(transport, socket, opts, timeout) do
-        :ok -> {:ok, socket, "#{host}:#{port}"}
+        :ok -> case host do
+          {:local, unix_socket_path} -> {:ok, socket, unix_socket_path}
+          host -> {:ok, socket, "#{host}:#{port}"}
+        end
         {:error, reason} -> {:stop, reason}
       end
     end

--- a/lib/redix/pubsub/connection.ex
+++ b/lib/redix/pubsub/connection.ex
@@ -615,7 +615,10 @@ defmodule Redix.PubSub.Connection do
     if opts[:sentinel] do
       "sentinel"
     else
-      "#{opts[:host]}:#{opts[:port]}"
+      case opts[:host] do
+        {:local, path} -> path
+        host -> "#{host}:#{opts[:port]}"
+      end
     end
   end
 end


### PR DESCRIPTION
Hello. Redix crashes when using a Unix socket because `:host` is tuple like `{:local, "redis.sock"}` which won't interpolate into strings like `"#{opts[:host]}:#{opts[:port]}"`.

This is a quick fix that got it working for my use case.