### PR TITLE
Allow port to be explicitly 0 when using Unix domain sockets

### DIFF
--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -122,6 +122,9 @@ defmodule Redix.StartOptions do
             raise ArgumentError,
                   "when using Unix domain sockets, the port must be 0, got: #{inspect(port)}"
 
+          {{:local, _unix_socket_path} = host, {:ok, 0}} ->
+            {host, 0}
+
           {{:local, _unix_socket_path} = host, :error} ->
             {host, 0}
 

--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -118,12 +118,14 @@ defmodule Redix.StartOptions do
     else
       {host, port} =
         case {Keyword.get(options, :host, "localhost"), Keyword.fetch(options, :port)} do
-          {{:local, _unix_socket_path}, {:ok, port}} when port != 0 ->
-            raise ArgumentError,
-                  "when using Unix domain sockets, the port must be 0, got: #{inspect(port)}"
-
           {{:local, _unix_socket_path} = host, {:ok, 0}} ->
             {host, 0}
+
+          {{:local, _unix_socket_path}, {:ok, non_zero_port}} ->
+            raise ArgumentError,
+                  "when using Unix domain sockets, the port must be 0, got: #{
+                    inspect(non_zero_port)
+                  }"
 
           {{:local, _unix_socket_path} = host, :error} ->
             {host, 0}

--- a/test/redix/start_options_test.exs
+++ b/test/redix/start_options_test.exs
@@ -34,6 +34,9 @@ defmodule Redix.StartOptionsTest do
       opts = StartOptions.sanitize(host: {:local, "some_path"})
       assert opts[:port] == 0
 
+      opts = StartOptions.sanitize(host: {:local, "some_path"}, port: 0)
+      assert opts[:port] == 0
+
       assert_raise ArgumentError, ~r/when using Unix domain sockets, the port must be 0/, fn ->
         StartOptions.sanitize(host: {:local, "some_path"}, port: 1)
       end


### PR DESCRIPTION
If the port can specified in the options to starting `Redix`, it is easier to switch between TCP host/port configuration and Unix domain sockets.