### PR TITLE
Match empty string path on database connection URI

### DIFF
--- a/lib/redix/uri.ex
+++ b/lib/redix/uri.ex
@@ -39,7 +39,7 @@ defmodule Redix.URI do
     end
   end
 
-  defp database(%URI{path: path}) when path in [nil, "/"] do
+  defp database(%URI{path: path}) when path in [nil, "", "/"] do
     nil
   end
 

--- a/test/redix/uri_test.exs
+++ b/test/redix/uri_test.exs
@@ -55,6 +55,11 @@ defmodule Redix.URITest do
     assert opts[:host] == "localhost"
     assert is_nil(opts[:database])
 
+    # test without a trailing slash
+    opts = opts_from_uri("redis://localhost")
+    assert opts[:host] == "localhost"
+    assert is_nil(opts[:database])
+
     opts = opts_from_uri("redis://localhost/2/namespace")
     assert opts[:host] == "localhost"
     assert opts[:database] == 2


### PR DESCRIPTION
Elixir 1.13 has changed the behaviour of URI.parse/1 to default
the path to an empty string instead of nil. 

https://github.com/elixir-lang/elixir/commit/e414cc0e83e2b389638ec04149ce761599b5d149

For the URI `redis://localhost:6379` In elixir 1.12.3 the path is nil

```
URI.parse("redis://localhost:6379")
%URI{
  authority: "localhost:6379",
  fragment: nil,
  host: "localhost",
  path: nil,
  port: 6379,
  query: nil,
  scheme: "redis",
  userinfo: nil
}
```

In elixir 1.13-rc.0 the path is an empty string

```
URI.parse("redis://localhost:6379")
%URI{
  authority: "localhost:6379",
  fragment: nil,
  host: "localhost",
  path: "",
  port: 6379,
  query: nil,
  scheme: "redis",
  userinfo: nil
}
```

which results in the following error on startup:

```
** (Mix) Could not start application bazaar: Bazaar.Application.start(:normal, [BazaarOps]) returned an error: shutdown: failed to start child: RedixSupervisor
    ** (EXIT) shutdown: failed to start child: Bazaar.Redix
        ** (EXIT) an exception was raised:
            ** (FunctionClauseError) no function clause matching in Redix.URI.database/1
                (redix 1.0.0) lib/redix/uri.ex:36: Redix.URI.database(%URI{authority: "localhost:6379", fragment: nil, host: "localhost", path: "", port: 6379, query: nil, scheme: "redis", userinfo: nil})
                (redix 1.0.0) lib/redix/uri.ex:16: Redix.URI.opts_from_uri/1
                (redix 1.0.0) lib/redix.ex:318: Redix.start_link/2
```

This fix adds an empty string to the nil database path match.
