### PR TITLE
Add telemetry_options for pipeline events

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -425,8 +425,8 @@ defmodule Redix do
       milliseconds). Defaults to `#{@default_timeout}`. If the Redis server
       doesn't reply within this timeout, `{:error,
       %Redix.ConnectionError{reason: :timeout}}` is returned.
-    * `:telemetry_options` - (map) extra metadata to add to the
-      `[:redix, :pipeline, :start | :stop]` telemetry events
+    * `:telemetry_metadata` - (map) extra metadata to add to the
+      `[:redix, :pipeline, :start | :stop]` telemetry events in `metadata[:options]`.
 
   ## Examples
 
@@ -731,7 +731,7 @@ defmodule Redix do
       conn,
       commands,
       opts[:timeout] || @default_timeout,
-      opts[:telemetry_options]
+      opts[:telemetry_metadata] || %{}
     )
   end
 

--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -425,6 +425,8 @@ defmodule Redix do
       milliseconds). Defaults to `#{@default_timeout}`. If the Redis server
       doesn't reply within this timeout, `{:error,
       %Redix.ConnectionError{reason: :timeout}}` is returned.
+    * `:extra_telemetry_metadata` - (map) extra metadata to add to the
+      `[:redix, :pipeline, :start | :stop]` telemetry events
 
   ## Examples
 
@@ -725,7 +727,12 @@ defmodule Redix do
   end
 
   defp pipeline_without_checks(conn, commands, opts) do
-    Redix.Connection.pipeline(conn, commands, opts[:timeout] || @default_timeout)
+    Redix.Connection.pipeline(
+      conn,
+      commands,
+      opts[:timeout] || @default_timeout,
+      opts[:extra_telemetry_metadata] || %{}
+    )
   end
 
   defp assert_valid_pipeline_commands([] = _commands) do

--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -425,7 +425,7 @@ defmodule Redix do
       milliseconds). Defaults to `#{@default_timeout}`. If the Redis server
       doesn't reply within this timeout, `{:error,
       %Redix.ConnectionError{reason: :timeout}}` is returned.
-    * `:extra_telemetry_metadata` - (map) extra metadata to add to the
+    * `:telemetry_options` - (map) extra metadata to add to the
       `[:redix, :pipeline, :start | :stop]` telemetry events
 
   ## Examples
@@ -731,7 +731,7 @@ defmodule Redix do
       conn,
       commands,
       opts[:timeout] || @default_timeout,
-      opts[:extra_telemetry_metadata] || %{}
+      opts[:telemetry_options]
     )
   end
 

--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -56,13 +56,12 @@ defmodule Redix.Connection do
     :gen_statem.stop(conn, :normal, timeout)
   end
 
-  def pipeline(conn, commands, timeout, extra_metadata \\ %{}) do
+  def pipeline(conn, commands, timeout, telemetry_options \\ nil) do
     conn_pid = GenServer.whereis(conn)
 
     request_id = Process.monitor(conn_pid)
 
-    telemetry_metadata =
-      telemetry_pipeline_metadata(conn, conn_pid, commands) |> Map.merge(extra_metadata)
+    telemetry_metadata = telemetry_pipeline_metadata(conn, conn_pid, commands, telemetry_options)
 
     start_time = System.monotonic_time()
     :ok = execute_telemetry_pipeline_start(telemetry_metadata)
@@ -83,7 +82,7 @@ defmodule Redix.Connection do
     end
   end
 
-  defp telemetry_pipeline_metadata(conn, conn_pid, commands) do
+  defp telemetry_pipeline_metadata(conn, conn_pid, commands, telemetry_options) do
     name =
       if is_pid(conn) do
         nil
@@ -94,7 +93,8 @@ defmodule Redix.Connection do
     %{
       connection: conn_pid,
       connection_name: name,
-      commands: commands
+      commands: commands,
+      options: telemetry_options
     }
   end
 

--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -56,12 +56,12 @@ defmodule Redix.Connection do
     :gen_statem.stop(conn, :normal, timeout)
   end
 
-  def pipeline(conn, commands, timeout, telemetry_options \\ nil) do
+  def pipeline(conn, commands, timeout, telemetry_metadata) do
     conn_pid = GenServer.whereis(conn)
 
     request_id = Process.monitor(conn_pid)
 
-    telemetry_metadata = telemetry_pipeline_metadata(conn, conn_pid, commands, telemetry_options)
+    telemetry_metadata = telemetry_pipeline_metadata(conn, conn_pid, commands, telemetry_metadata)
 
     start_time = System.monotonic_time()
     :ok = execute_telemetry_pipeline_start(telemetry_metadata)
@@ -82,7 +82,7 @@ defmodule Redix.Connection do
     end
   end
 
-  defp telemetry_pipeline_metadata(conn, conn_pid, commands, telemetry_options) do
+  defp telemetry_pipeline_metadata(conn, conn_pid, commands, telemetry_metadata) do
     name =
       if is_pid(conn) do
         nil
@@ -94,7 +94,7 @@ defmodule Redix.Connection do
       connection: conn_pid,
       connection_name: name,
       commands: commands,
-      options: telemetry_options
+      options: telemetry_metadata
     }
   end
 

--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -56,12 +56,14 @@ defmodule Redix.Connection do
     :gen_statem.stop(conn, :normal, timeout)
   end
 
-  def pipeline(conn, commands, timeout) do
+  def pipeline(conn, commands, timeout, extra_metadata \\ %{}) do
     conn_pid = GenServer.whereis(conn)
 
     request_id = Process.monitor(conn_pid)
 
-    telemetry_metadata = telemetry_pipeline_metadata(conn, conn_pid, commands)
+    telemetry_metadata =
+      telemetry_pipeline_metadata(conn, conn_pid, commands) |> Map.merge(extra_metadata)
+
     start_time = System.monotonic_time()
     :ok = execute_telemetry_pipeline_start(telemetry_metadata)
 

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -800,7 +800,7 @@ defmodule RedixTest do
       :telemetry.detach(to_string(test_name))
     end
 
-    test "supports the :extra_telemetry_metadata option", %{conn: c} do
+    test "supports the :telemetry_options option", %{conn: c} do
       {test_name, _arity} = __ENV__.function
 
       parent = self()
@@ -819,18 +819,17 @@ defmodule RedixTest do
         :no_config
       )
 
-      assert {:ok, ["PONG"]} =
-               Redix.pipeline(c, [["PING"]], extra_telemetry_metadata: %{extra: 42})
+      assert {:ok, ["PONG"]} = Redix.pipeline(c, [["PING"]], telemetry_options: %{extra: 42})
 
       assert_receive {^ref, [:redix, :pipeline, :start], measurements, meta}
       assert is_integer(measurements.system_time)
       assert meta.commands == [["PING"]]
-      assert meta.extra == 42
+      assert meta.options == %{extra: 42}
 
       assert_receive {^ref, [:redix, :pipeline, :stop], measurements, meta}
       assert is_integer(measurements.duration) and measurements.duration > 0
       assert meta.commands == [["PING"]]
-      assert meta.extra == 42
+      assert meta.options == %{extra: 42}
 
       :telemetry.detach(to_string(test_name))
     end

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -800,7 +800,7 @@ defmodule RedixTest do
       :telemetry.detach(to_string(test_name))
     end
 
-    test "supports the :telemetry_options option", %{conn: c} do
+    test "supports the :telemetry_metadata option", %{conn: c} do
       {test_name, _arity} = __ENV__.function
 
       parent = self()
@@ -819,7 +819,7 @@ defmodule RedixTest do
         :no_config
       )
 
-      assert {:ok, ["PONG"]} = Redix.pipeline(c, [["PING"]], telemetry_options: %{extra: 42})
+      assert {:ok, ["PONG"]} = Redix.pipeline(c, [["PING"]], telemetry_metadata: %{extra: 42})
 
       assert_receive {^ref, [:redix, :pipeline, :start], measurements, meta}
       assert is_integer(measurements.system_time)


### PR DESCRIPTION
Hi, thanks for your work in providing and maintaining this library! We would like to start using the built-in telemetry events for our monitoring needs, and it would be helpful for us if it was possible to add extra metadata to telemetry events; e.g. in our case we commonly use "operation names" for our redis metrics, to make it easy to distinguish between various redis pipeline executions... I've outlined a possible way to add this to the library in this PR. Is this something you would consider adding to the library? Thanks! 