### PR TITLE
Add warning for servers potentially blocking CLIENT commands

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -73,6 +73,10 @@ defmodule Redix do
   Skipping replies is useful to improve performance when you want to issue many commands
   but are not interested in the responses to those commands.
 
+  > ⚠️ Some servers may block `CLIENT` commands.
+  > For example, Google Memorystorage is [known to do so](https://cloud.google.com/memorystore/docs/redis/product-constraints).
+  > If this is the case, functions mentioned above won't work.
+
   ## SSL
 
   Redix supports SSL by passing `ssl: true` in `start_link/1`. You can use the `:socket_opts`


### PR DESCRIPTION
This bite me pretty hard today https://github.com/whatyouhide/redix/issues/192 so I thought it would be nice to mention this issue in the doc, especially given that the error's trace is not immediately obvious:

```
** (ArgumentError) argument error
 (stdlib 3.14.2.2) :ets.lookup_element(#Reference<0.3067823838.3890610178.94977>, :"$end_of_table", 3)
 (redix 1.1.2) lib/redix/socket_owner.ex:114: Redix.SocketOwner.peek_element_in_queue/2
 (redix 1.1.2) lib/redix/socket_owner.ex:90: Redix.SocketOwner.new_data/2
 (redix 1.1.2) lib/redix/socket_owner.ex:56: Redix.SocketOwner.handle_info/2
 (stdlib 3.14.2.2) gen_server.erl:689: :gen_server.try_dispatch/4
 (stdlib 3.14.2.2) gen_server.erl:765: :gen_server.handle_msg/6
 (stdlib 3.14.2.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:tcp, #Port<0.46>, "-ERR unknown command `CLIENT`, with args beginning with: `REPLY`, `OFF`, \r\n:1\r\n-ERR unknown command `CLIENT`, with args beginning with: `REPLY`, `ON`, \r\n"}
```