### PR TITLE
Fix telemetry warning

### DIFF
--- a/lib/redix/telemetry.ex
+++ b/lib/redix/telemetry.ex
@@ -130,7 +130,12 @@ defmodule Redix.Telemetry do
       [:redix, :failed_connection]
     ]
 
-    :telemetry.attach_many("redix-default-telemetry-handler", events, &handle_event/4, :no_config)
+    :telemetry.attach_many(
+      "redix-default-telemetry-handler",
+      events,
+      &__MODULE__.handle_event/4,
+      :no_config
+    )
   end
 
   # This function handles only log-related events (disconnections, reconnections, and so on).


### PR DESCRIPTION
warning from logs:
```
The function passed as a handler with ID "redix-default-telemetry-handler" is a local function.
This means that it is either an anonymous function or a capture of a function without a module specified. That may cause a performance penalty when calling that handler. For more details see the note in `telemetry:attach/4` documentation.

https://hexdocs.pm/telemetry/telemetry.html#attach/4
```