### PR TITLE
make sure to pass reconnection with sync_connect

### DIFF
--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -143,7 +143,8 @@ defmodule Redix.Connection do
           :telemetry.execute([:redix, :connection], %{}, %{
             connection: self(),
             connection_name: data.opts[:name],
-            address: address
+            address: address,
+            reconnection: false
           })
 
           {:ok, :connected, %__MODULE__{data | socket: socket, connected_address: address}}


### PR DESCRIPTION
We are using the `sync_connect` option for our redis connection. This causes our telemetry handler to always error and detach. Error:

```
Handler "redix-default-telemetry-handler" has failed and has been detached. Class=:error
Reason={:case_clause,
 {:connection,
  %{
    address: [REDACTED],
    connection: #PID<0.535.0>,
    connection_name: :primary
  }}}
Stacktrace=[
  {Redix.Telemetry, :handle_event, 4,
   [file: 'lib/redix/telemetry.ex', line: 148]},
  {:telemetry, :"-execute/3-fun-0-", 4,
   [file: '/opt/app/deps/telemetry/src/telemetry.erl', line: 160]},
  {:lists, :foreach, 2, [file: 'lists.erl', line: 1342]},
  {Redix.Connection, :init, 1, [file: 'lib/redix/connection.ex', line: 143]},
  {:gen_statem, :init_it, 6, [file: 'gen_statem.erl', line: 802]},
  {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}
]
```

It seems like the `:telemetry.execute` inside the `init` callback is not passing the `reconnection` key and therefore is always crashing the handler.