### PR TITLE
Fix Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ No bug fixes or improvements. Just enough years passed for this to become 1.0.0!
 
   * Use the new Telemetry event conventions for pipeline-related events. The new events are `[:redix, :pipeline, :start]` and `[:redix, :pipeline, :stop]`. They both have new measurements associated with them.
   * Remove the `[:redix, :reconnection]` Telemetry event in favor or `[:redix, :connection]`, which is emitted anytime there's a successful connection to a Redis server.
-  * Remove support for the deprecated ``:log` start option (which was deprecated on v0.10.0).
+  * Remove support for the deprecated `:log` start option (which was deprecated on v0.10.0).
 
 ### Bug fixes and improvements
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,8 @@ defmodule Redix.Mixfile do
           "pages/Reconnections.md",
           "pages/Real-world usage.md",
           "pages/Telemetry.md",
-          "CHANGELOG.md"
+          "CHANGELOG.md",
+          "LICENSE.txt": [title: "License"]
         ]
       ]
     ]


### PR DESCRIPTION
This backtick ...
![image](https://user-images.githubusercontent.com/50892128/218554502-3099e009-ac2f-4e85-8d49-1d72709e2f54.png)
...messes up the formatting for all changelog versions `v0.11.0` and older.

This PR fixes that so the changelog properly renders:
![image](https://user-images.githubusercontent.com/50892128/218554884-e5807404-a1ea-40c1-9b84-d5ffe360ed02.png)
