### PR TITLE
Support MFA for `:password` in `:sentinel` option

### DIFF
--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -210,6 +210,7 @@ defmodule Redix.StartOptions do
         ],
         password: [
           type: {:or, [:string, :mfa]},
+          type_doc: "`String.t/0` or `{mod, fun, args}`",
           doc: """
           if you don't want to specify a password for each sentinel you
           list, you can use this option to specify a password that will be used to authenticate

--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -209,7 +209,7 @@ defmodule Redix.StartOptions do
           """
         ],
         password: [
-          type: :string,
+          type: {:or, [:string, :mfa]},
           doc: """
           if you don't want to specify a password for each sentinel you
           list, you can use this option to specify a password that will be used to authenticate


### PR DESCRIPTION
This PR makes it possible to specify a common `:password` option for sentinels as an MFA. For example:

```elixir
Redix.start_link(
  sentinel: [
    group: "mymaster",
    sentinels: [
      [host: "localhost", port: 26379]
    ],
    password: {System, :fetch_env!, ["PASSWORD"]}
  ]
)
```

Currently, the schema in `Redix.StartOptions` only allows this option to be a string, even though it allows to use an MFA for the `:password` option in each individual sentinel in the `:sentinels` list. It already works in the implementation, however, so this PR simply expands the `NimbleOptions` `:type` for the option and adds additional test cases. 