### PR TITLE
Store client ID in `Redix.PubSub`

### DIFF
--- a/lib/redix/connector.ex
+++ b/lib/redix/connector.ex
@@ -250,7 +250,13 @@ defmodule Redix.Connector do
     end
   end
 
-  defp sync_command(transport, socket, command, timeout) do
+  @spec sync_command(
+          :ssl | :gen_tcp,
+          :gen_tcp.socket() | :ssl.sslsocket(),
+          [String.t()],
+          integer()
+        ) :: {:ok, any} | {:error, any}
+  def sync_command(transport, socket, command, timeout) do
     with :ok <- transport.send(socket, Redix.Protocol.pack(command)),
          do: recv_response(transport, socket, &Redix.Protocol.parse/1, timeout)
   end

--- a/lib/redix/pubsub.ex
+++ b/lib/redix/pubsub.ex
@@ -416,4 +416,16 @@ defmodule Redix.PubSub do
       when is_binary(patterns) or is_list(patterns) do
     :gen_statem.call(conn, {:punsubscribe, List.wrap(patterns), subscriber})
   end
+
+  @doc """
+  Gets the redis `CLIENT ID` associated with a connection
+  ## Examples
+
+      iex> Redix.PubSub.client_id(conn)
+      {:ok, 123}
+  """
+  @spec client_id(connection()) :: {:ok, integer()} | {:error, any()}
+  def client_id(conn) do
+    :gen_statem.call(conn, :client_id)
+  end
 end

--- a/test/redix/pubsub_test.exs
+++ b/test/redix/pubsub_test.exs
@@ -23,6 +23,11 @@ defmodule Redix.PubSubTest do
     assert info[:fullsweep_after] == fullsweep_after
   end
 
+  test "client_id should be available after start_link/2" do
+    {:ok, pid} = PubSub.start_link(port: @port)
+    assert match?({:ok, client_id} when is_number(client_id), PubSub.client_id(pid))
+  end
+
   test "subscribe/unsubscribe flow", %{pubsub: pubsub, conn: conn} do
     # First, we subscribe.
     assert {:ok, ref} = PubSub.subscribe(pubsub, ["foo", "bar"], self())


### PR DESCRIPTION
Wasn't exactly sure what direction to take this, issuing "sync" commands within the pubsub is awkward, let me know if you'd prefer a different approach.

One thing to note though, for the redirecting invalidations from normal connections to the pubsub, the client id should be available as early as possible.

closes #260 

