### PR TITLE
Add support for Valkey schema

### DIFF
--- a/lib/redix/uri.ex
+++ b/lib/redix/uri.ex
@@ -26,8 +26,8 @@ defmodule Redix.URI do
   def to_start_options(uri) when is_binary(uri) do
     %URI{host: host, port: port, scheme: scheme} = uri = URI.parse(uri)
 
-    unless scheme in ["redis", "rediss"] do
-      raise ArgumentError, "expected scheme to be redis:// or rediss://, got: #{scheme}://"
+    unless scheme in ["redis", "rediss", "valkey"] do
+      raise ArgumentError, "expected scheme to be redis://, valkey:// or rediss://, got: #{scheme}://"
     end
 
     {username, password} = username_and_password(uri)


### PR DESCRIPTION
Following Redis' decision to switch from BSD to a dual-license model, many are switching to Valkey instead.
I couldn't find a specific Valkey client for Elixir so I've decided to open a PR in this library to add support for `valkey://` schema instead.

AFAIK Valkey is 100% compatible with Redis