### PR TITLE
update real world usage connection pool to use supervisor behavior

### DIFF
--- a/pages/Real-world usage.md
+++ b/pages/Real-world usage.md
@@ -31,21 +31,24 @@ When you want to have a pool of connections, you can start many connections and 
 
 ```elixir
 defmodule MyApp.Redix do
+  use Supervisor
+
   @pool_size 5
 
-  def child_spec(_args) do
-    # Specs for the Redix connections.
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
     children =
       for index <- 0..(@pool_size - 1) do
+        # Specs for the Redix connections.
         Supervisor.child_spec({Redix, name: :"redix_#{index}"}, id: {Redix, index})
       end
 
     # Spec for the supervisor that will supervise the Redix connections.
-    %{
-      id: RedixSupervisor,
-      type: :supervisor,
-      start: {Supervisor, :start_link, [children, [strategy: :one_for_one]]}
-    }
+    Supervisor.init(children, strategy: :one_for_one)
   end
 
   def command(command) do


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX182tJgYDyJKsN6WXcvXb4Jsyk21OaQqYQ%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=mkQ6zOI)

My setup requires the children defined before `MyApp.Redix` to be started before its `child_spec` can run (need to read some data from somewhere else) and I struggled for a bit with it so I think it might be worth updating the document to a more fool-proof default.

I think `use Supervisor` is better than manually setup through `child_spec` since it follows OTP convention and is easier to debug, it also means whichever is specified before `MyApp.Redix` in the main supervisor tree is actually started before we do anything with  `MyApp.Redix`.