### PR TITLE
Fix code example typo

### DIFF
--- a/lib/redix/pubsub.ex
+++ b/lib/redix/pubsub.ex
@@ -159,7 +159,7 @@ defmodule Redix.PubSub do
         {:redix_pubsub, ^pubsub, ^ref, :subscribed, %{channel: "my_channel"}} -> :ok
       end
 
-      Redix.command!(client, ~w(PUBLISH my_channel hello)
+      Redix.command!(client, ~w(PUBLISH my_channel hello))
 
       receive do
         {:redix_pubsub, ^pubsub, ^ref, :message, %{channel: "my_channel"} = properties} ->


### PR DESCRIPTION
Just noticed this while I was copy pasting from the example