### PR TITLE
Default to using Erlang certificate store

### DIFF
--- a/lib/redix.ex
+++ b/lib/redix.ex
@@ -82,11 +82,13 @@ defmodule Redix do
   Redix supports SSL by passing `ssl: true` in `start_link/1`. You can use the `:socket_opts`
   option to pass options that will be used by the SSL socket, like certificates.
 
-  If the [CAStore](https://hex.pm/packages/castore) dependency is available, Redix will pick
-  up its CA certificate store file automatically. You can select a different CA certificate
-  store by passing in the `:cacertfile` or `:cacerts` socket options. If the server uses a
-  self-signed certificate, such as for testing purposes, disable certificate verification by
-  passing `verify: :verify_none` in the socket options.
+  If you are using Erlang/OTP 25+, Redix will use the system CA certificate store
+  automatically. If that is not available and the [CAStore](https://hex.pm/packages/castore)
+  dependency is available, Redix will use the CA certificate store file from CAStore
+  instead. You can select a different CA certificate store by passing in the `:cacertfile`
+  or `:cacerts` socket options. If the server uses a self-signed certificate, such as for
+  testing purposes, disable certificate verification by passing `verify: :verify_none` in
+  the socket options.
 
   Some Redis servers, notably Amazon ElastiCache, use wildcard certificates that require
   additional socket options for successful verification (requires OTP 21.0 or later):

--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -119,8 +119,9 @@ defmodule Redix.StartOptions do
       overridden by Redix so that it functions properly.
 
       If `ssl: true`, then these are added to the default: `[verify: :verify_peer, depth: 3]`.
-      If the `CAStore` dependency is available, the `:cacertfile` option is added
-      to the SSL options by default as well.
+      If you are using Erlang/OTP 25+ or if the `CAStore` dependency is available, the
+      `:cacerts` or `:cacertfile` option is added to the SSL options by default as well,
+      unless either option is already specified.
       """
     ],
     hibernate_after: [


### PR DESCRIPTION
If supplied, the `:cacerts` option overrides `:cacertfile`, so we have to check if the user has specified a different CA certificate store before adding them to the default options.

The OTP team no longer supports Erlang versions earlier than 25+, so we are assuming that `:public_key.cacerts_get/0` is available.

Closes https://github.com/whatyouhide/redix/issues/278