### PR TITLE
Introduce health checks for long-running commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
     is unchanged.
   * Add a `:readonly` option to `Redix.start_link/1` that issues `READONLY` after every
     (re)connection.
+  * Add a `:health_check_interval` option to `Redix.start_link/1` that detects *half-open*
+    connections (the socket is open but the server stopped replying) and reconnects. This
+    fixes slow recovery after a Sentinel failover where the old primary is paused (for
+    example via `CLIENT PAUSE`): the reconnection re-queries the sentinels and lands on the
+    new primary instead of staying wedged. Defaults to `:infinity` (disabled).
 
 ## v1.5.3
 

--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -374,8 +374,8 @@ defmodule Redix.Connection do
         else
           upcased = String.upcase(name)
 
-          name in @blocking_commands or
-            (name in ["XREAD", "XREADGROUP"] and
+          upcased in @blocking_commands or
+            (upcased in ["XREAD", "XREADGROUP"] and
                Enum.any?(
                  args,
                  &(is_binary(&1) and byte_size(&1) == 5 and String.upcase(&1) == "BLOCK")

--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -15,6 +15,7 @@ defmodule Redix.Connection do
     :socket,
     :backoff_current,
     :connected_address,
+    :health_marker,
     counter: 0,
     client_reply: :on
   ]
@@ -157,7 +158,8 @@ defmodule Redix.Connection do
             reconnection: false
           })
 
-          {:ok, :connected, %__MODULE__{data | socket: socket, connected_address: address}}
+          data = %__MODULE__{data | socket: socket, connected_address: address}
+          {:ok, :connected, data, health_check_actions(data)}
 
         {:stopped, ^socket_owner, reason} ->
           {:stop, %Redix.ConnectionError{reason: reason}}
@@ -202,6 +204,14 @@ defmodule Redix.Connection do
     :keep_state_and_data
   end
 
+  # A health-check timeout is a *generic* (named) gen_statem timeout, which is not
+  # auto-cancelled when we leave the :connected state. If a normal disconnection happens
+  # with a health check armed, the leftover timer can fire here: ignore it. The next time
+  # we reach :connected we arm a fresh timer (which replaces any leftover by name).
+  def disconnected({:timeout, :health_check}, _timer_info, _data) do
+    :keep_state_and_data
+  end
+
   # This happens when there's a send error. We close the socket right away, but we wait for
   # the socket owner to die so that it can finish processing the data it's processing. When it's
   # dead, we go ahead and notify the remaining clients, setup backoff, and so on.
@@ -229,12 +239,25 @@ defmodule Redix.Connection do
       reconnection: not is_nil(data.backoff_current)
     })
 
-    data = %{data | socket: socket, backoff_current: nil, connected_address: address}
-    {:next_state, :connected, %{data | socket: socket}}
+    data = %{
+      data
+      | socket: socket,
+        backoff_current: nil,
+        connected_address: address,
+        health_marker: nil
+    }
+
+    {:next_state, :connected, %{data | socket: socket}, health_check_actions(data)}
   end
 
   def connecting(:cast, {:pipeline, _commands, _from}, _data) do
     {:keep_state_and_data, :postpone}
+  end
+
+  # See the matching clause in disconnected/3: a leftover health-check timer can fire while
+  # we're reconnecting. Ignore it; it'll be re-armed once we're connected again.
+  def connecting({:timeout, :health_check}, _timer_info, _data) do
+    :keep_state_and_data
   end
 
   def connecting(:info, {:stopped, owner, reason}, %__MODULE__{socket_owner: owner} = data) do
@@ -290,7 +313,40 @@ defmodule Redix.Connection do
     disconnect(data, reason)
   end
 
+  # Periodic liveness check (only armed when :health_check_interval is set). We use the
+  # commands queue table as the progress signal: the socket owner deletes a row as soon as
+  # it receives the matching reply, and command counters are monotonic, so the smallest key
+  # (`:ets.first/1`) is the oldest in-flight command and can never repeat for a different one.
+  def connected({:timeout, :health_check}, _timer_info, %__MODULE__{} = data) do
+    case :ets.first(data.table) do
+      :"$end_of_table" ->
+        # Nothing in flight: the connection is idle, so there's nothing to check.
+        {:keep_state, %{data | health_marker: nil}, health_check_actions(data)}
+
+      oldest when oldest == data.health_marker ->
+        # The same command has been in flight for a full interval without a reply. The socket
+        # is still open but the server isn't making progress (half-open connection, e.g. an
+        # old primary paused during a Sentinel failover). Tear it down so we reconnect and,
+        # for Sentinel, re-resolve the current primary. We let the socket owner stop (which
+        # closes the socket it owns) and drive the disconnection through {:stopped, ...}.
+        send(data.socket_owner, {:force_disconnect, self(), :health_check_timeout})
+        {:keep_state, %{data | health_marker: nil}}
+
+      oldest ->
+        # Either progress was made since the last tick or this is the first time we see this
+        # command. Remember it and re-check next interval.
+        {:keep_state, %{data | health_marker: oldest}, health_check_actions(data)}
+    end
+  end
+
   ## Helpers
+
+  defp health_check_actions(%__MODULE__{opts: opts}) do
+    case Keyword.fetch!(opts, :health_check_interval) do
+      :infinity -> []
+      interval -> [{{:timeout, :health_check}, interval, nil}]
+    end
+  end
 
   # `from` is a process alias (see pipeline/4). Sending to a deactivated alias (e.g. after
   # the caller timed out) is silently dropped, so we never leak late replies.

--- a/lib/redix/connection.ex
+++ b/lib/redix/connection.ex
@@ -189,7 +189,7 @@ defmodule Redix.Connection do
   end
 
   def disconnected(:internal, {:notify_of_disconnection, _reason}, %__MODULE__{table: table}) do
-    fun = fn {_counter, from, _ncommands}, _acc ->
+    fun = fn {_counter, from, _ncommands, _blocking?}, _acc ->
       reply(from, {:error, %ConnectionError{reason: :disconnected}})
     end
 
@@ -201,14 +201,6 @@ defmodule Redix.Connection do
 
   def disconnected(:cast, {:pipeline, _commands, from}, _data) do
     reply(from, {:error, %ConnectionError{reason: :closed}})
-    :keep_state_and_data
-  end
-
-  # A health-check timeout is a *generic* (named) gen_statem timeout, which is not
-  # auto-cancelled when we leave the :connected state. If a normal disconnection happens
-  # with a health check armed, the leftover timer can fire here: ignore it. The next time
-  # we reach :connected we arm a fresh timer (which replaces any leftover by name).
-  def disconnected({:timeout, :health_check}, _timer_info, _data) do
     :keep_state_and_data
   end
 
@@ -254,12 +246,6 @@ defmodule Redix.Connection do
     {:keep_state_and_data, :postpone}
   end
 
-  # See the matching clause in disconnected/3: a leftover health-check timer can fire while
-  # we're reconnecting. Ignore it; it'll be re-armed once we're connected again.
-  def connecting({:timeout, :health_check}, _timer_info, _data) do
-    :keep_state_and_data
-  end
-
   def connecting(:info, {:stopped, owner, reason}, %__MODULE__{socket_owner: owner} = data) do
     # We log this when the socket owner stopped while connecting.
     :telemetry.execute([:redix, :failed_connection], %{}, %{
@@ -278,7 +264,7 @@ defmodule Redix.Connection do
     if ncommands > 0 do
       {counter, data} = get_and_update_in(data.counter, &{&1, &1 + 1})
 
-      row = {counter, from, ncommands}
+      row = {counter, from, ncommands, blocking_pipeline?(commands)}
       :ets.insert(data.table, row)
 
       case data.transport.send(data.socket, Enum.map(commands, &Protocol.pack/1)) do
@@ -317,20 +303,33 @@ defmodule Redix.Connection do
   # commands queue table as the progress signal: the socket owner deletes a row as soon as
   # it receives the matching reply, and command counters are monotonic, so the smallest key
   # (`:ets.first/1`) is the oldest in-flight command and can never repeat for a different one.
-  def connected({:timeout, :health_check}, _timer_info, %__MODULE__{} = data) do
+  #
+  # We use a :state_timeout (not a generic/named timeout) so gen_statem auto-cancels it when
+  # we leave the :connected state, and (unlike an event timeout) it is *not* reset by incoming
+  # events, so a busy-but-wedged connection that keeps receiving pipeline casts still fires.
+  def connected(:state_timeout, :health_check, %__MODULE__{} = data) do
     case :ets.first(data.table) do
       :"$end_of_table" ->
         # Nothing in flight: the connection is idle, so there's nothing to check.
         {:keep_state, %{data | health_marker: nil}, health_check_actions(data)}
 
       oldest when oldest == data.health_marker ->
-        # The same command has been in flight for a full interval without a reply. The socket
-        # is still open but the server isn't making progress (half-open connection, e.g. an
-        # old primary paused during a Sentinel failover). Tear it down so we reconnect and,
-        # for Sentinel, re-resolve the current primary. We let the socket owner stop (which
-        # closes the socket it owns) and drive the disconnection through {:stopped, ...}.
-        send(data.socket_owner, {:force_disconnect, self(), :health_check_timeout})
-        {:keep_state, %{data | health_marker: nil}}
+        if blocking_row?(data.table, oldest) do
+          # The head-of-line command is a known blocking command (BLPOP, WAIT,
+          # XREAD BLOCK). It is *supposed* to sit there without a reply, so we don't count it
+          # as a stall. Detection resumes automatically once it completes and the queue head
+          # advances to a non-blocking command.
+          {:keep_state_and_data, health_check_actions(data)}
+        else
+          # The same non-blocking command has been in flight for a full interval without a
+          # reply. The socket is still open but the server isn't making progress (half-open
+          # connection, e.g. an old primary paused during a Sentinel failover). Tear it down
+          # so we reconnect and, for Sentinel, re-resolve the current primary. We let the
+          # socket owner stop (which closes the socket it owns) and drive the disconnection
+          # through {:stopped, ...}.
+          send(data.socket_owner, {:force_disconnect, self(), :health_check_timeout})
+          {:keep_state, %{data | health_marker: nil}}
+        end
 
       oldest ->
         # Either progress was made since the last tick or this is the first time we see this
@@ -344,8 +343,48 @@ defmodule Redix.Connection do
   defp health_check_actions(%__MODULE__{opts: opts}) do
     case Keyword.fetch!(opts, :health_check_interval) do
       :infinity -> []
-      interval -> [{{:timeout, :health_check}, interval, nil}]
+      interval -> [{:state_timeout, interval, :health_check}]
     end
+  end
+
+  # The set of Redis commands that intentionally hold a connection open waiting for data,
+  # producing no immediate reply. The health check skips a teardown while one of these is at
+  # the head of the in-flight queue, so it never trips on a legitimately-blocked connection.
+  @blocking_commands MapSet.new(~w(
+    BLPOP BRPOP BLMOVE BRPOPLPUSH BLMPOP
+    BZPOPMIN BZPOPMAX BZMPOP
+    WAIT WAITAOF
+  ))
+
+  # Longest entry above, used to skip upcasing arbitrarily large command names (see #177).
+  @max_blocking_command_size @blocking_commands |> Enum.map(&byte_size/1) |> Enum.max()
+
+  defp blocking_row?(table, key) do
+    case :ets.lookup(table, key) do
+      [{^key, _from, _ncommands, blocking?}] -> blocking?
+      _other -> false
+    end
+  end
+
+  defp blocking_pipeline?(commands) do
+    Enum.any?(commands, fn
+      [name | args] ->
+        if byte_size(name) > @max_blocking_command_size do
+          false
+        else
+          upcased = String.upcase(name)
+
+          name in @blocking_commands or
+            (name in ["XREAD", "XREADGROUP"] and
+               Enum.any?(
+                 args,
+                 &(is_binary(&1) and byte_size(&1) == 5 and String.upcase(&1) == "BLOCK")
+               ))
+        end
+
+      _other ->
+        false
+    end)
   end
 
   # `from` is a process alias (see pipeline/4). Sending to a deactivated alias (e.g. after

--- a/lib/redix/exceptions.ex
+++ b/lib/redix/exceptions.ex
@@ -38,6 +38,10 @@ defmodule Redix.ConnectionError do
 
     * `:timeout`: when Redis doesn't reply to the request in time.
 
+    * `:health_check_timeout`: when the `:health_check_interval` option is set and an
+      in-flight command goes unanswered for longer than that interval, so Redix closes
+      the connection and reconnects.
+
   """
 
   @typedoc """
@@ -72,6 +76,11 @@ defmodule Redix.ConnectionError do
   # Returned during sentinel connections when the server has an
   # unexpected role (for example, "master" instead of "slave").
   defp format_reason({:wrong_role, role}), do: "wrong role: #{role}"
+
+  # Returned when a health check fails: an in-flight command went unanswered for
+  # longer than the :health_check_interval, so Redix tore the connection down.
+  defp format_reason(:health_check_timeout),
+    do: "a command went unanswered for longer than the configured :health_check_interval"
 
   if System.otp_release() >= "26" do
     defp format_reason(reason) when is_atom(reason) do

--- a/lib/redix/socket_owner.ex
+++ b/lib/redix/socket_owner.ex
@@ -122,7 +122,7 @@ defmodule Redix.SocketOwner do
   defp new_data(%{continuation: continuation} = state, data) do
     case continuation.(data) do
       {:ok, resp, rest} ->
-        {_counter, alias_ref, _ncommands} = take_first_in_queue(state.queue_table)
+        {_counter, alias_ref, _ncommands, _blocking?} = take_first_in_queue(state.queue_table)
 
         # `alias_ref` is a process alias (see Redix.Connection.pipeline/4). If the caller
         # already timed out, the alias is deactivated and this reply is silently dropped.

--- a/lib/redix/socket_owner.ex
+++ b/lib/redix/socket_owner.ex
@@ -50,6 +50,13 @@ defmodule Redix.SocketOwner do
     end
   end
 
+  # The connection is asking us to tear down because a health check failed (an in-flight
+  # command went unanswered for too long). We stop normally; exiting closes the socket we
+  # own, and the {:stopped, ...} message we send drives the reconnection on the connection.
+  def handle_info({:force_disconnect, conn, reason}, %__MODULE__{conn: conn} = state) do
+    stop(reason, state)
+  end
+
   # The connection is notifying the socket owner that sending failed. If the socket owner
   # gets this, it can stop normally without waiting for the "closed"/"error" network
   # message from the socket.

--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -60,6 +60,26 @@ defmodule Redix.StartOptions do
       connection timeout (in milliseconds) directly passed to the network layer.
       """
     ],
+    health_check_interval: [
+      type: :timeout,
+      default: :infinity,
+      doc: """
+      if set to a number of milliseconds, Redix periodically checks that in-flight commands
+      are making progress. If a command stays in flight (sent to Redis but not yet answered)
+      for longer than this interval, Redix considers the connection broken, even if the
+      underlying socket is still open, then closes it and reconnects. This catches "half-open"
+      connections where the server stops replying without closing the socket, which
+      otherwise leave Redix hanging until eventually the socket goes down. The most
+      common case is a Redis Sentinel failover: the old primary is paused (for example via
+      `CLIENT PAUSE`) while a replica is promoted, so commands time out but the socket stays
+      open. Reconnecting re-runs the connection logic, which for Sentinel means re-querying
+      the sentinels for the *current* primary. Detection happens within one to two intervals.
+      `:infinity` disables the check (the historical behavior). Do not
+      enable this on connections that issue blocking commands (such as `BLPOP` or
+      `XREAD BLOCK`), since those legitimately keep a command in flight with no reply.
+      *Available since v1.6.0.*
+      """
+    ],
     sync_connect: [
       type: :boolean,
       default: false,
@@ -252,7 +272,13 @@ defmodule Redix.StartOptions do
   @redix_start_link_opts_schema start_link_opts_schema
                                 |> Keyword.drop([:fetch_client_id_on_connect])
                                 |> NimbleOptions.new!()
-  @redix_pubsub_start_link_opts_schema NimbleOptions.new!(start_link_opts_schema)
+
+  # The health check monitors in-flight command progress, which doesn't map onto
+  # the pub/sub connection (it idles waiting for server-pushed messages), so the
+  # option is only exposed for regular Redix connections.
+  @redix_pubsub_start_link_opts_schema start_link_opts_schema
+                                       |> Keyword.drop([:health_check_interval])
+                                       |> NimbleOptions.new!()
 
   @spec options_docs(:redix | :redix_pubsub) :: String.t()
   def options_docs(:redix), do: NimbleOptions.docs(@redix_start_link_opts_schema)

--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -74,10 +74,11 @@ defmodule Redix.StartOptions do
       `CLIENT PAUSE`) while a replica is promoted, so commands time out but the socket stays
       open. Reconnecting re-runs the connection logic, which for Sentinel means re-querying
       the sentinels for the *current* primary. Detection happens within one to two intervals.
-      `:infinity` disables the check (the historical behavior). Do not
-      enable this on connections that issue blocking commands (such as `BLPOP` or
-      `XREAD BLOCK`), since those legitimately keep a command in flight with no reply.
-      *Available since v1.6.0.*
+      `:infinity` disables the check (the historical behavior). Blocking commands (such as
+      `BLPOP`, `WAIT`, or `XREAD`/`XREADGROUP` with `BLOCK`) are handled automatically: while
+      one of them is at the head of the in-flight queue the check is suspended, so it won't
+      trip on a connection that is legitimately waiting, and it resumes as soon as the
+      blocking command completes. *Available since v1.6.0.*
       """
     ],
     sync_connect: [

--- a/pages/Reconnections.md
+++ b/pages/Reconnections.md
@@ -16,7 +16,7 @@ The `:health_check_interval` option makes Redix proactive about this. When set, 
 Redix.start_link(sentinel: sentinel_config, health_check_interval: 1_000)
 ```
 
-Detection happens within one to two intervals. Do **not** enable this on connections that issue blocking commands (such as `BLPOP` or `XREAD BLOCK`), since those legitimately keep a command in flight with no reply and would be torn down as false positives. The option defaults to `:infinity`, which disables the check.
+Detection happens within one to two intervals. Blocking commands (such as `BLPOP`, `WAIT`, or `XREAD`/`XREADGROUP` with `BLOCK`) are handled automatically: while one of them is at the head of the in-flight queue, the check is suspended so it won't trip on a connection that is legitimately waiting for data, and it resumes as soon as the blocking command completes. The option defaults to `:infinity`, which disables the check entirely.
 
 ## Synchronous or asynchronous connection
 

--- a/pages/Reconnections.md
+++ b/pages/Reconnections.md
@@ -6,6 +6,18 @@ If there are pending requests to Redix when a disconnection happens, the `Redix`
 
 The first reconnection attempts happens after a backoff interval decided by the `:backoff_initial` option. If this attempt succeeds, then Redix will start to function normally again. If this attempt fails, then subsequent reconnection attempts are made until one of them succeeds. The backoff interval between these subsequent reconnection attempts is increased exponentially (with a fixed factor of `1.5`). This means that the first attempt will be made after `n` milliseconds, the second one after `n * 1.5` milliseconds, the third one after `n * 1.5 * 1.5` milliseconds, and so on. Since this growth is exponential, it won't take many attempts before this backoff interval becomes large: because of this, `Redix.start_link/2` also accepts a `:backoff_max` option. which specifies the maximum backoff interval that should be used. The `:backoff_max` option can be used to simulate constant backoff after some exponential backoff attempts: for example, by passing `backoff_max: 5_000` and `backoff_initial: 5_000`, attempts will be made regularly every 5 seconds.
 
+## Detecting half-open connections
+
+The reconnection logic above kicks in when the TCP socket to Redis actually goes down. Sometimes, though, the socket stays *open* while the server stops replying (a "**half-open**" connection.) The classic example is a Redis Sentinel failover: the old primary is often paused (for example via `CLIENT PAUSE`) while a replica is promoted, so commands sent on the existing socket simply time out instead of failing. Redix can't tell this apart from a slow server, so by default it keeps the connection and your commands return `{:error, %Redix.ConnectionError{reason: :timeout}}` until the OS eventually tears the socket down (which can take a long time).
+
+The `:health_check_interval` option makes Redix proactive about this. When set, Redix periodically checks that in-flight commands are making progress; if a command stays in flight for longer than the interval without a reply, Redix considers the connection broken, closes it, and reconnects. For a Sentinel connection, reconnecting re-runs the full connection logic, including re-querying the sentinels, so Redix lands on the *current* primary rather than staying wedged on the old one. The disconnection is reported through the usual `[:redix, :disconnection]` telemetry event with `reason: %Redix.ConnectionError{reason: :health_check_timeout}`.
+
+```elixir
+Redix.start_link(sentinel: sentinel_config, health_check_interval: 1_000)
+```
+
+Detection happens within one to two intervals. Do **not** enable this on connections that issue blocking commands (such as `BLPOP` or `XREAD BLOCK`), since those legitimately keep a command in flight with no reply and would be torn down as false positives. The option defaults to `:infinity`, which disables the check.
+
 ## Synchronous or asynchronous connection
 
 The `:sync_connect` option passed to `Redix.start_link/2` decides whether Redix should initiate the TCP connection to the Redis server *before* or *after* `Redix.start_link/2` returns. This option also changes the behaviour of Redix when the TCP connection can't be initiated at all.

--- a/test/redix/health_check_test.exs
+++ b/test/redix/health_check_test.exs
@@ -1,0 +1,240 @@
+defmodule Redix.HealthCheckTest do
+  use ExUnit.Case, async: true
+
+  alias Redix.ConnectionError
+
+  # These tests use a fully controllable fake TCP server (no Docker needed) to
+  # reproduce a *half-open* connection: the server accepts the socket and stays
+  # connected, but never replies to commands. This is what happens during a
+  # Sentinel failover when the old primary is paused (e.g. `CLIENT PAUSE`) — the
+  # socket stays open, commands time out, and without a health check Redix stays
+  # wedged on the dead primary instead of reconnecting and re-resolving it.
+  # See https://github.com/whatyouhide/redix/issues/287.
+
+  setup do
+    {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+    {:ok, port} = :inet.port(listen)
+    on_exit(fn -> :gen_tcp.close(listen) end)
+    %{listen: listen, port: port}
+  end
+
+  test "reconnects when an in-flight command goes unanswered for the interval", %{
+    listen: listen,
+    port: port
+  } do
+    # A server that accepts connections but never replies to any command.
+    accept_loop(listen)
+
+    {test_name, _arity} = __ENV__.function
+    parent = self()
+
+    handler = fn event, _measurements, meta, _config ->
+      if meta.connection_name == test_name, do: send(parent, {event, meta})
+    end
+
+    :ok =
+      :telemetry.attach_many(
+        to_string(test_name),
+        [[:redix, :disconnection], [:redix, :connection]],
+        handler,
+        :no_config
+      )
+
+    on_exit(fn -> :telemetry.detach(to_string(test_name)) end)
+
+    conn =
+      start_supervised!(
+        {Redix,
+         host: "127.0.0.1",
+         port: port,
+         name: test_name,
+         sync_connect: true,
+         health_check_interval: 100}
+      )
+
+    # The command never gets a reply; the caller times out...
+    assert {:error, %ConnectionError{reason: :timeout}} =
+             Redix.command(conn, ["GET", "foo"], timeout: 50)
+
+    # ...but unlike before, the *connection* now notices the stalled command and
+    # tears itself down with a :health_check_timeout reason, then reconnects.
+    assert_receive {[:redix, :disconnection], meta}, 1000
+    assert %ConnectionError{reason: :health_check_timeout} = meta.reason
+
+    assert_receive {[:redix, :connection], %{reconnection: true}}, 1000
+  end
+
+  test "without a health check, a half-open connection stays wedged (the bug)", %{
+    listen: listen,
+    port: port
+  } do
+    accept_loop(listen)
+
+    {test_name, _arity} = __ENV__.function
+    parent = self()
+
+    handler = fn _event, _measurements, meta, _config ->
+      if meta.connection_name == test_name, do: send(parent, :disconnected)
+    end
+
+    :ok = :telemetry.attach(to_string(test_name), [:redix, :disconnection], handler, :no_config)
+    on_exit(fn -> :telemetry.detach(to_string(test_name)) end)
+
+    conn =
+      start_supervised!(
+        {Redix, host: "127.0.0.1", port: port, name: test_name, sync_connect: true}
+      )
+
+    assert {:error, %ConnectionError{reason: :timeout}} =
+             Redix.command(conn, ["GET", "foo"], timeout: 50)
+
+    # The command timed out, but the connection itself never notices it's wedged:
+    # no disconnection, no reconnection. It's pinned to the dead server.
+    refute_receive :disconnected, 300
+  end
+
+  test "survives a normal disconnection with a health check armed", %{listen: listen, port: port} do
+    # The server answers one PING, then closes the socket. With a health-check interval far
+    # shorter than the reconnect backoff, the (generic) health-check timer is still armed when
+    # we drop into the disconnected/connecting states and will fire there. The connection must
+    # ignore it rather than crash. Regression guard for the leftover-timer case.
+    pinged = self()
+
+    accept_loop(listen, fn ["PING"] ->
+      send(pinged, :got_ping)
+      :close
+    end)
+
+    conn =
+      start_supervised!(
+        {Redix,
+         host: "127.0.0.1",
+         port: port,
+         sync_connect: true,
+         health_check_interval: 30,
+         backoff_initial: 500,
+         backoff_max: 500}
+      )
+
+    # Trigger the close; the caller sees the disconnection.
+    Redix.command(conn, ["PING"], timeout: 200)
+    assert_receive :got_ping, 500
+
+    # Let the leftover health-check timer fire during the backoff window, then confirm the
+    # connection process is still alive (it didn't crash on the stray timeout).
+    Process.sleep(200)
+    assert Process.alive?(GenServer.whereis(conn))
+  end
+
+  test "does not tear down a healthy idle connection", %{listen: listen, port: port} do
+    # A server that answers PING with PONG and otherwise stays connected.
+    accept_loop(listen, fn
+      ["PING"] -> "+PONG\r\n"
+      _ -> "+OK\r\n"
+    end)
+
+    {test_name, _arity} = __ENV__.function
+    parent = self()
+
+    handler = fn _event, _measurements, meta, _config ->
+      if meta.connection_name == test_name, do: send(parent, :disconnected)
+    end
+
+    :ok = :telemetry.attach(to_string(test_name), [:redix, :disconnection], handler, :no_config)
+    on_exit(fn -> :telemetry.detach(to_string(test_name)) end)
+
+    conn =
+      start_supervised!(
+        {Redix,
+         host: "127.0.0.1",
+         port: port,
+         name: test_name,
+         sync_connect: true,
+         health_check_interval: 50}
+      )
+
+    assert Redix.command!(conn, ["PING"]) == "PONG"
+
+    # The connection sits idle across several health-check intervals and must not
+    # be torn down — the check only fires on *unanswered in-flight* commands.
+    refute_receive :disconnected, 300
+    assert Redix.command!(conn, ["PING"]) == "PONG"
+  end
+
+  # Accepts one connection and serves it. With no handler, never replies (the
+  # half-open case). With a handler, replies to each parsed command.
+  defp accept_loop(listen, handler \\ nil) do
+    test_pid = self()
+
+    spawn_link(fn ->
+      case :gen_tcp.accept(listen, 5_000) do
+        {:ok, socket} -> serve(socket, handler, "")
+        {:error, _reason} -> Process.unlink(test_pid)
+      end
+    end)
+
+    :ok
+  end
+
+  defp serve(socket, handler, buffer) do
+    case :gen_tcp.recv(socket, 0, 5_000) do
+      {:ok, data} ->
+        buffer = buffer <> data
+
+        if handler do
+          {commands, rest} = parse_commands(buffer, [])
+
+          if Enum.any?(commands, &(handler.(&1) == :close)) do
+            # A handler can ask us to drop the connection after replying to the
+            # commands before the one that returned :close.
+            Enum.each(commands, fn command ->
+              case handler.(command) do
+                :close -> :gen_tcp.close(socket)
+                reply -> :gen_tcp.send(socket, reply)
+              end
+            end)
+          else
+            Enum.each(commands, &:gen_tcp.send(socket, handler.(&1)))
+            serve(socket, handler, rest)
+          end
+        else
+          # Half-open: read and discard, never reply.
+          serve(socket, handler, "")
+        end
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp parse_commands(buffer, acc) do
+    case parse_command(buffer) do
+      {:ok, command, rest} -> parse_commands(rest, [command | acc])
+      :incomplete -> {Enum.reverse(acc), buffer}
+    end
+  end
+
+  defp parse_command("*" <> rest) do
+    case Integer.parse(rest) do
+      {n, "\r\n" <> rest} -> parse_args(rest, n, [])
+      _ -> :incomplete
+    end
+  end
+
+  defp parse_command(_other), do: :incomplete
+
+  defp parse_args(rest, 0, acc), do: {:ok, Enum.reverse(acc), rest}
+
+  defp parse_args("$" <> rest, n, acc) do
+    case Integer.parse(rest) do
+      {len, "\r\n" <> rest} when byte_size(rest) >= len + 2 ->
+        <<arg::binary-size(^len), "\r\n", rest::binary>> = rest
+        parse_args(rest, n - 1, [arg | acc])
+
+      _ ->
+        :incomplete
+    end
+  end
+
+  defp parse_args(_rest, _n, _acc), do: :incomplete
+end

--- a/test/redix/health_check_test.exs
+++ b/test/redix/health_check_test.exs
@@ -93,11 +93,47 @@ defmodule Redix.HealthCheckTest do
     refute_receive :disconnected, 300
   end
 
+  test "does not tear down while a blocking command is in flight", %{listen: listen, port: port} do
+    # The server replies to PING but never to BLPOP (simulating a command legitimately
+    # blocking, waiting for data). The health check must NOT tear the connection down while
+    # a known blocking command sits at the head of the in-flight queue.
+    accept_loop(listen, fn
+      ["PING"] -> "+PONG\r\n"
+      ["BLPOP" | _] -> :no_reply
+    end)
+
+    {test_name, _arity} = __ENV__.function
+    parent = self()
+
+    handler = fn _event, _measurements, meta, _config ->
+      if meta.connection_name == test_name, do: send(parent, :disconnected)
+    end
+
+    :ok = :telemetry.attach(to_string(test_name), [:redix, :disconnection], handler, :no_config)
+    on_exit(fn -> :telemetry.detach(to_string(test_name)) end)
+
+    conn =
+      start_supervised!(
+        {Redix,
+         host: "127.0.0.1",
+         port: port,
+         name: test_name,
+         sync_connect: true,
+         health_check_interval: 50}
+      )
+
+    # Issue BLPOP from a separate task so it can sit in flight indefinitely.
+    Task.async(fn -> Redix.command(conn, ["BLPOP", "key", "0"], timeout: :infinity) end)
+
+    # Across several health-check intervals, the connection must stay up because the
+    # head-of-line command is a recognized blocking command.
+    refute_receive :disconnected, 400
+  end
+
   test "survives a normal disconnection with a health check armed", %{listen: listen, port: port} do
-    # The server answers one PING, then closes the socket. With a health-check interval far
-    # shorter than the reconnect backoff, the (generic) health-check timer is still armed when
-    # we drop into the disconnected/connecting states and will fire there. The connection must
-    # ignore it rather than crash. Regression guard for the leftover-timer case.
+    # The server answers one PING, then closes the socket. A :state_timeout health check is
+    # auto-cancelled by gen_statem when we leave the :connected state, so the reconnection
+    # must proceed cleanly without any stray timer crashing the process.
     pinged = self()
 
     accept_loop(listen, fn ["PING"] ->
@@ -182,20 +218,21 @@ defmodule Redix.HealthCheckTest do
         buffer = buffer <> data
 
         if handler do
+          # A handler returns iodata to send, `:no_reply` to stay silent (simulating a
+          # blocking command), or `:close` to drop the connection. We keep serving unless
+          # we closed.
           {commands, rest} = parse_commands(buffer, [])
 
-          if Enum.any?(commands, &(handler.(&1) == :close)) do
-            # A handler can ask us to drop the connection after replying to the
-            # commands before the one that returned :close.
-            Enum.each(commands, fn command ->
-              case handler.(command) do
-                :close -> :gen_tcp.close(socket)
-                reply -> :gen_tcp.send(socket, reply)
-              end
-            end)
-          else
-            Enum.each(commands, &:gen_tcp.send(socket, handler.(&1)))
+          if Enum.reduce_while(commands, :open, fn command, :open ->
+               case handler.(command) do
+                 :close -> {:halt, :closed}
+                 :no_reply -> {:cont, :open}
+                 reply -> :gen_tcp.send(socket, reply) && {:cont, :open}
+               end
+             end) == :open do
             serve(socket, handler, rest)
+          else
+            :gen_tcp.close(socket)
           end
         else
           # Half-open: read and discard, never reply.


### PR DESCRIPTION
The idea here is to verify how long it takes to run a command, and if a command is taking too long, then shut down the connection. This prevents "stuck" connections where the OS socket hasn't been closed but Redis paused the client and whatnot.

Closes #287.