### PR TITLE
Reject :exit_on_disconnection in cluster mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,16 +106,18 @@ This eliminates the need for `persistent_term` or any external lookup.
   `:disconnected` and triggers the first topology fetch via an internal `:next_event`;
   failures retry on a `:state_timeout` with the same exponential backoff as
   `Redix.Connection` (`:backoff_initial`/`:backoff_max` conn opts, exponent 1.5, reset
-  on success). Commands check a `{:topology_discovered, true}` marker in the slot
-  table (one ETS lookup; set on the first successful fetch, after the table and
-  Registry are populated); while it's absent they block on
+  on success). Commands check a `{:discovery_attempted, true}` marker in the slot
+  table (one ETS lookup; set when the *initial* fetch attempt completes — on
+  success after the table and Registry are populated, on failure right away in the
+  `:disconnected` state); while it's absent they block on
   `Manager.await_topology_discovery/2` — a call whose only job is to queue behind
-  the in-flight fetch event, mirroring how `Redix.Connection` postpones pipelines in
-  its `:connecting` state. If the fetch succeeded the caller's lookups now find the
-  topology; between backoff retries the Manager replies immediately, so commands
-  fail fast with `%Redix.ConnectionError{reason: :closed}` (empty slot table, no
-  registered connections), like single Redix in `:disconnected`. Reactive refresh
-  casts are dropped while `:disconnected` (the retry timer is in charge), and
+  the in-flight fetch event, mirroring how `Redix.Connection` postpones pipelines
+  while connecting. So commands only ever await that one initial attempt: if it
+  succeeded their lookups find the topology, and once it failed they fail fast with
+  `%Redix.ConnectionError{reason: :closed}` (empty slot table, no registered
+  connections) without contacting the Manager again — no blocking callers on every
+  backoff retry when the cluster couldn't be reached on the first try. Reactive
+  refresh casts are dropped while `:disconnected` (the retry timer is in charge), and
   `connect_to_node` calls are still served. With `sync_connect: true`, `init/1` fetches
   synchronously and returns `{:stop, reason}` on failure so `start_link/1` fails fast.
   Node connections always use `sync_connect: false` regardless: the cluster-level

--- a/lib/redix/cluster.ex
+++ b/lib/redix/cluster.ex
@@ -183,7 +183,10 @@ defmodule Redix.Cluster do
   #{NimbleOptions.docs(@start_link_opts_schema)}
 
   All other standard `Redix` connection options (`:password`, `:ssl`, `:socket_opts`,
-  `:timeout`, and so on) are passed through to *each underlying node connection*.
+  `:timeout`, and so on) are passed through to *each underlying node connection*. The
+  exceptions are `:sentinel` and `:exit_on_disconnection`, which are not supported in
+  cluster mode (the cluster supervises node connections and handles disconnections
+  itself).
 
   ## Examples
 
@@ -212,6 +215,14 @@ defmodule Redix.Cluster do
 
     if Keyword.has_key?(conn_opts, :sentinel) do
       raise ArgumentError, "Sentinel connections are not supported in cluster mode"
+    end
+
+    if Keyword.has_key?(conn_opts, :exit_on_disconnection) do
+      raise ArgumentError, """
+      the :exit_on_disconnection option is not supported in cluster mode: node \
+      connections are supervised by the cluster, which handles disconnections and \
+      topology changes itself\
+      """
     end
 
     conn_opts = Redix.StartOptions.sanitize(:redix, conn_opts)

--- a/lib/redix/cluster.ex
+++ b/lib/redix/cluster.ex
@@ -25,13 +25,13 @@ defmodule Redix.Cluster do
 
   Like single-node `Redix` connections, the cluster starts even if no seed node is
   currently reachable: the topology is discovered in the background, retrying with
-  exponential backoff. Commands issued while a discovery attempt is in flight wait
-  for it to complete (just like a single Redix connection postpones commands while
-  it's connecting), so the common "start the cluster, issue a command right away"
-  pattern works without retries. If discovery fails, commands return
-  `{:error, %Redix.ConnectionError{reason: :closed}}` until a seed node becomes
-  reachable. Pass `sync_connect: true` to `start_link/1` to block until the
-  topology has been discovered instead.
+  exponential backoff. Commands issued while the *initial* discovery attempt is in
+  flight wait for it to complete (just like a single Redix connection postpones
+  commands while it's connecting), so the common "start the cluster, issue a
+  command right away" pattern works without retries. If that first attempt fails,
+  commands return `{:error, %Redix.ConnectionError{reason: :closed}}` until a seed
+  node becomes reachable. Pass `sync_connect: true` to `start_link/1` to block
+  until the topology has been discovered instead.
 
   ### Pipelines
 
@@ -145,10 +145,10 @@ defmodule Redix.Cluster do
       `start_link/1` returns. When `false` (the default), `start_link/1` returns right
       away and the topology is fetched in the background, retrying with exponential
       backoff (driven by the `:backoff_initial` and `:backoff_max` options) until a
-      seed node answers. Commands issued while a discovery attempt is in flight wait
-      for it to complete (up to their `:timeout`); if discovery fails, they return
-      `{:error, %Redix.ConnectionError{reason: :closed}}` until a seed node becomes
-      reachable. When `true`, `start_link/1` blocks until the topology has been
+      seed node answers. Commands issued while the *initial* discovery attempt is in
+      flight wait for it to complete (up to their `:timeout`); once that attempt
+      fails, they return `{:error, %Redix.ConnectionError{reason: :closed}}` until a
+      seed node becomes reachable. When `true`, `start_link/1` blocks until the topology has been
       fetched, and returns an error if no seed node is reachable. This mirrors the
       `:sync_connect` option of `Redix.start_link/1`.
       """
@@ -818,16 +818,18 @@ defmodule Redix.Cluster do
   ## Helpers
 
   # Mirrors single-node Redix's behavior for commands issued right after an async
-  # start: Redix.Connection *postpones* pipelines while in its :connecting state, so
-  # they wait for the in-flight attempt instead of failing. Here, until the first
-  # topology fetch succeeds (no :topology_discovered marker in the slot table yet),
-  # we block on the Manager — whose call queue makes us wait out exactly the fetch
-  # attempt in flight, if any — and then fall through to normal resolution. If the
-  # fetch failed, resolution finds nothing and the command fails fast with :closed,
-  # like single Redix between reconnection attempts. Once the marker is set this
-  # costs one ETS lookup and is never looked at again.
+  # start: Redix.Connection *postpones* pipelines while its first connection attempt
+  # is in flight, so they wait for it instead of failing. Here, until the *initial*
+  # topology fetch attempt completes (no :discovery_attempted marker in the slot
+  # table yet), we block on the Manager — whose call queue makes us wait out exactly
+  # the attempt in flight — and then fall through to normal resolution. The marker is
+  # set when that first attempt completes, *success or failure*: if it failed,
+  # resolution finds nothing and this and all later commands fail fast with :closed
+  # (if the cluster couldn't be reached on the first try it might be a while before
+  # it can, so blocking callers for every backoff retry wouldn't help). Once the
+  # marker is set this costs one ETS lookup and the Manager is never contacted again.
   defp await_topology_discovery(cluster, slot_table, opts) do
-    unless :ets.member(slot_table, :topology_discovered) do
+    unless :ets.member(slot_table, :discovery_attempted) do
       timeout = Keyword.get(opts, :timeout, @default_timeout)
       Manager.await_topology_discovery(manager_name(cluster), timeout)
     end
@@ -1029,6 +1031,8 @@ defmodule Redix.Cluster do
   catch
     :throw, {:error, reason} ->
       {:error, "invalid node in :nodes list: " <> reason}
+  else
+    parsed_nodes -> {:ok, parsed_nodes}
   end
 
   def __parse_nodes__(other) do

--- a/lib/redix/cluster/manager.ex
+++ b/lib/redix/cluster/manager.ex
@@ -131,15 +131,18 @@ defmodule Redix.Cluster.Manager do
   end
 
   @doc """
-  Blocks until the topology fetch attempt currently in flight (if any) has completed.
+  Blocks until the *initial* topology fetch attempt has completed.
 
-  Mirrors how a single Redix connection *postpones* commands while in its
-  `:connecting` state: callers that find the slot table still unpopulated (no
-  `:topology_discovered` marker yet) call this before resolving connections. The
-  call queues behind the fetch the manager is performing, so the reply arrives
-  once that attempt is done; if it succeeded the caller's lookups now find the
+  Mirrors how a single Redix connection *postpones* commands while its first
+  connection attempt is in flight: callers that find no `:discovery_attempted`
+  marker in the slot table yet call this before resolving connections. The call
+  queues behind the fetch the manager is performing, so the reply arrives once
+  that attempt is done; if it succeeded the caller's lookups now find the
   topology, and if it failed they fall through to the normal "no connection"
-  error, matching single Redix's fail-fast behavior between reconnection attempts.
+  error. The marker is set once the first attempt completes — success or failure —
+  so commands only ever await that one attempt: after a failed first try the
+  cluster might be unreachable for a while, and blocking every caller for each
+  backoff retry wouldn't help.
 
   The reply carries no information on purpose; exits (caller timeout, dead
   manager) degrade to `:ok` so callers always just retry their lookups.
@@ -233,9 +236,10 @@ defmodule Redix.Cluster.Manager do
   ## State: :disconnected. The initial topology fetch hasn't succeeded yet
   ## (async connect, the default). Retries with exponential backoff until a seed
   ## node answers, mirroring how a single Redix connection reconnects. Commands
-  ## issued while a fetch attempt is in flight await its completion (see
-  ## await_topology_discovery/2); between retries they fail fast with a
-  ## connection error since the slot table is empty.
+  ## issued while the *initial* fetch attempt is in flight await its completion
+  ## (see await_topology_discovery/2); once that attempt has completed — success
+  ## or failure — they resolve straight from the slot table, so after a failed
+  ## first attempt they fail fast with a connection error.
 
   def disconnected(event_type, :connect, data)
       when event_type in [:internal, :state_timeout] do
@@ -245,6 +249,11 @@ defmodule Redix.Cluster.Manager do
         {:next_state, :ready, data, [periodic_refresh_action(data.refresh_interval)]}
 
       {:error, _reason} ->
+        # The attempt completed (just unsuccessfully), so set the marker: commands
+        # stop awaiting and fail fast — if we couldn't reach the cluster on the
+        # first try, it might be a while before we can, and blocking every caller
+        # for each retry wouldn't help. do_refresh_topology/1 sets it on success.
+        :ets.insert(data.slot_table, {:discovery_attempted, true})
         {backoff, data} = next_backoff(data)
         {:keep_state, data, [{:state_timeout, backoff, :connect}]}
     end
@@ -266,11 +275,11 @@ defmodule Redix.Cluster.Manager do
     handle_connect_to_node(from, host, port, data)
   end
 
-  # This call is only ever *processed* between fetch attempts (events are atomic,
-  # so a call arriving mid-attempt queues until the attempt is done — that
-  # queueing is the whole point, see await_topology_discovery/2). Replying right
-  # away makes commands fail fast between backoff retries, matching single
-  # Redix's :disconnected state.
+  # This call is only ever *processed* after the initial fetch attempt completed
+  # (events are atomic, so a call arriving mid-attempt queues until the attempt
+  # is done — that queueing is the whole point, see await_topology_discovery/2).
+  # By then the :discovery_attempted marker is set, so replying right away sends
+  # the caller back to a lookup that fails fast.
   def disconnected({:call, from}, :await_topology_discovery, _data) do
     {:keep_state_and_data, [{:reply, from, :ok}]}
   end
@@ -308,9 +317,8 @@ defmodule Redix.Cluster.Manager do
     handle_connect_to_node(from, host, port, data)
   end
 
-  # The topology is already discovered; a caller can only land here by racing a
-  # refresh (it checked the marker just before the table was rewritten, which
-  # never removes the marker). Reply right away.
+  # The initial fetch already completed; a caller can only land here by racing
+  # the marker insert (the marker is never removed). Reply right away.
   def ready({:call, from}, :await_topology_discovery, _data) do
     {:keep_state_and_data, [{:reply, from, :ok}]}
   end
@@ -438,14 +446,15 @@ defmodule Redix.Cluster.Manager do
         update_slot_map(data, slots_data)
         data = ensure_connections(data, slots_data)
 
-        # Marks that at least one topology fetch has succeeded. Callers check this
-        # before resolving connections: while it's absent they await the in-flight
+        # Marks that the initial topology fetch attempt has completed (the
+        # :disconnected state sets the same marker on failure). Callers check this
+        # before resolving connections: while it's absent they await the initial
         # fetch via await_topology_discovery/2 instead of failing right away.
         # Inserted *after* the slot table and Registry are populated, so a caller
         # that sees the marker also sees a routable topology. A 2-tuple can't
         # collide with the {slot, primary, replicas} entries or with
         # update_slot_map/2's 3-tuple select/delete patterns.
-        :ets.insert(data.slot_table, {:topology_discovered, true})
+        :ets.insert(data.slot_table, {:discovery_attempted, true})
 
         node_addresses =
           for {node_id, _host, _port, _role} <- nodes_to_connect(data, slots_data), do: node_id

--- a/pages/Cluster.md
+++ b/pages/Cluster.md
@@ -33,7 +33,7 @@ Redix.Cluster.command(:my_cluster, ["GET", "mykey"])
 
 Like single-node `Redix` connections, starting a cluster does **not** require any node to be reachable. By default, `Redix.Cluster.start_link/1` returns right away and discovers the cluster topology in the background, retrying with exponential backoff (controlled by the `:backoff_initial` and `:backoff_max` options) until a seed node answers. This means a `Redix.Cluster` in your supervision tree won't crash-loop your application at boot if Redis comes up *after* your app.
 
-Commands issued while a discovery attempt is in flight **wait for it to complete** (up to their `:timeout`), just like a single `Redix` connection postpones commands while it's connecting — so starting a cluster and issuing commands right away works without retries. If discovery fails (no seed node is reachable), commands return `{:error, %Redix.ConnectionError{reason: :closed}}` until a node becomes reachable.
+Commands issued while the *initial* discovery attempt is in flight **wait for it to complete** (up to their `:timeout`), just like a single `Redix` connection postpones commands while it's connecting — so starting a cluster and issuing commands right away works without retries. Once that first attempt fails (no seed node is reachable), commands stop waiting and return `{:error, %Redix.ConnectionError{reason: :closed}}` until a node becomes reachable.
 
 If you prefer to block until the topology has been discovered—and fail fast if no seed node is reachable—pass `sync_connect: true`:
 

--- a/test/redix/cluster/async_connect_test.exs
+++ b/test/redix/cluster/async_connect_test.exs
@@ -1,0 +1,248 @@
+defmodule Redix.Cluster.AsyncConnectTest do
+  use ExUnit.Case, async: true
+
+  # Tests for the cluster's startup behavior (issue #323): by default the initial
+  # topology fetch happens *after* start_link/1 returns and is retried with backoff
+  # until a seed node answers, mirroring single-node Redix's lazy connect. With
+  # sync_connect: true the fetch is synchronous and start_link/1 fails fast. We
+  # drive a real Redix.Cluster against a scriptable fake RESP node so we can
+  # control exactly when the "cluster" becomes reachable — same pattern as
+  # slot_map_refresh_test.exs.
+
+  test "async connect (the default): starts up even when no node is reachable, " <>
+         "then discovers the topology in the background" do
+    cluster = :"async_#{System.unique_integer([:positive])}"
+
+    {:ok, listen} =
+      :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true, packet: :raw])
+
+    {:ok, port} = :inet.port(listen)
+    node_id = "127.0.0.1:#{port}"
+
+    # The fake node starts "down": it accepts connections but closes them right
+    # away, so the topology fetch fails at the socket level.
+    {:ok, state} = Agent.start_link(fn -> :down end)
+
+    serve(listen, state, fn
+      ["CLUSTER", "SLOTS"] -> cluster_slots([{0, 16_383, node_id}])
+      ["PING"] -> "+PONG\r\n"
+      _other -> "+OK\r\n"
+    end)
+
+    :telemetry_test.attach_event_handlers(self(), [
+      [:redix, :cluster, :failed_topology_refresh],
+      [:redix, :cluster, :topology_change]
+    ])
+
+    # start_link returns right away even though the node is unreachable. A short
+    # backoff keeps the test fast.
+    start_supervised!(
+      {Redix.Cluster, name: cluster, nodes: ["redis://#{node_id}"], backoff_initial: 50}
+    )
+
+    # The node is down, so the initial discovery attempt fails: commands await at
+    # most that first attempt and then fail fast with a connection error — both
+    # keyed commands (empty slot table) and keyless ones (no connections).
+    assert Redix.Cluster.command(cluster, ["GET", "x"]) ==
+             {:error, %Redix.ConnectionError{reason: :closed}}
+
+    assert Redix.Cluster.command(cluster, ["PING"]) ==
+             {:error, %Redix.ConnectionError{reason: :closed}}
+
+    # The failed first attempt sets the marker, so commands no longer await the
+    # Manager (they'd otherwise block for in-flight backoff retries too).
+    assert :ets.member(:"#{cluster}_slots", :discovery_attempted)
+
+    # The Manager keeps retrying in the background.
+    assert_receive {[:redix, :cluster, :failed_topology_refresh], _ref, %{},
+                    %{cluster: ^cluster}},
+                   1_000
+
+    # The node comes up: the next retry discovers the topology and the cluster
+    # becomes usable with no intervention.
+    Agent.update(state, fn _ -> :up end)
+
+    assert_receive {[:redix, :cluster, :topology_change], _ref, %{}, %{cluster: ^cluster}},
+                   2_000
+
+    wait_until(fn -> Redix.Cluster.command(cluster, ["PING"]) == {:ok, "PONG"} end)
+
+    assert :ets.lookup(:"#{cluster}_slots", 0) == [{0, node_id, []}]
+  end
+
+  test "commands issued while the initial topology fetch is in flight wait for it " <>
+         "instead of failing" do
+    cluster = :"await_#{System.unique_integer([:positive])}"
+
+    {:ok, listen} =
+      :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true, packet: :raw])
+
+    {:ok, port} = :inet.port(listen)
+    node_id = "127.0.0.1:#{port}"
+
+    {:ok, state} = Agent.start_link(fn -> :up end)
+
+    # The node answers CLUSTER SLOTS slowly, so the first fetch is reliably still
+    # in flight when the command below is issued. Each connection is served in its
+    # own process, so the sleep doesn't block the node connection's PING.
+    serve(listen, state, fn
+      ["CLUSTER", "SLOTS"] ->
+        Process.sleep(300)
+        cluster_slots([{0, 16_383, node_id}])
+
+      ["PING"] ->
+        "+PONG\r\n"
+
+      _other ->
+        "+OK\r\n"
+    end)
+
+    start_supervised!({Redix.Cluster, name: cluster, nodes: ["redis://#{node_id}"]})
+
+    # Mirrors single-node Redix: the command awaits the in-flight fetch (and then
+    # the node connection, which postpones commands while connecting) instead of
+    # failing right away with :closed.
+    assert Redix.Cluster.command(cluster, ["PING"]) == {:ok, "PONG"}
+    assert Redix.Cluster.command(cluster, ["GET", "x"]) == {:ok, "OK"}
+  end
+
+  @tag :capture_log
+  test "sync_connect: true makes start_link/1 fail fast when no node is reachable" do
+    Process.flag(:trap_exit, true)
+
+    # Bind to an ephemeral port and close it again: connecting to it is then
+    # refused immediately.
+    {:ok, listen} = :gen_tcp.listen(0, [:binary, reuseaddr: true])
+    {:ok, port} = :inet.port(listen)
+    :ok = :gen_tcp.close(listen)
+
+    cluster = :"sync_#{System.unique_integer([:positive])}"
+
+    assert {:error, {:shutdown, {:failed_to_start_child, Redix.Cluster.Manager, reason}}} =
+             Redix.Cluster.start_link(
+               name: cluster,
+               nodes: ["redis://127.0.0.1:#{port}"],
+               sync_connect: true
+             )
+
+    assert reason == :no_reachable_node
+  end
+
+  test "nodes: [] is rejected at validation time" do
+    assert_raise NimbleOptions.ValidationError, ~r/expected a non-empty list of nodes/, fn ->
+      Redix.Cluster.start_link(name: :rejected_cluster, nodes: [])
+    end
+  end
+
+  ## Fake RESP node (shared shape with slot_map_refresh_test.exs). When the state
+  ## Agent holds :down, accepted connections are closed immediately to simulate an
+  ## unreachable node; when :up, commands are served through `handler`.
+
+  defp serve(listen, state, handler) do
+    spawn_link(fn -> accept_loop(listen, state, handler) end)
+  end
+
+  defp accept_loop(listen, state, handler) do
+    case :gen_tcp.accept(listen, 10_000) do
+      {:ok, socket} ->
+        case Agent.get(state, & &1) do
+          :down -> :gen_tcp.close(socket)
+          :up -> spawn_link(fn -> loop(socket, handler, "") end)
+        end
+
+        accept_loop(listen, state, handler)
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp loop(socket, handler, buffer) do
+    case :gen_tcp.recv(socket, 0, 10_000) do
+      {:ok, data} ->
+        {commands, rest} = parse_commands(buffer <> data, [])
+        Enum.each(commands, &:gen_tcp.send(socket, handler.(&1)))
+        loop(socket, handler, rest)
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  # Encodes a CLUSTER SLOTS reply from `{start, stop, "host:port"}` ranges, each
+  # owned by a single primary (no replicas).
+  defp cluster_slots(ranges) do
+    body =
+      Enum.map(ranges, fn {start, stop, node_id} ->
+        [host, port] = String.split(node_id, ":")
+
+        [
+          "*3\r\n",
+          ":#{start}\r\n",
+          ":#{stop}\r\n",
+          "*3\r\n",
+          "$#{byte_size(host)}\r\n",
+          host,
+          "\r\n",
+          ":#{port}\r\n",
+          "$40\r\n",
+          String.duplicate("a", 40),
+          "\r\n"
+        ]
+      end)
+
+    IO.iodata_to_binary(["*#{length(ranges)}\r\n", body])
+  end
+
+  ## Minimal RESP request parser (shared shape with slot_map_refresh_test.exs)
+
+  defp parse_commands(buffer, acc) do
+    case parse_command(buffer) do
+      {:ok, command, rest} -> parse_commands(rest, [command | acc])
+      :incomplete -> {Enum.reverse(acc), buffer}
+    end
+  end
+
+  defp parse_command("*" <> rest) do
+    with {:ok, count, rest} <- parse_int_line(rest) do
+      parse_bulk_strings(count, rest, [])
+    end
+  end
+
+  defp parse_command(_other), do: :incomplete
+
+  defp parse_bulk_strings(0, rest, acc), do: {:ok, Enum.reverse(acc), rest}
+
+  defp parse_bulk_strings(count, "$" <> rest, acc) do
+    with {:ok, length, rest} <- parse_int_line(rest) do
+      case rest do
+        <<value::binary-size(^length), "\r\n", rest::binary>> ->
+          parse_bulk_strings(count - 1, rest, [value | acc])
+
+        _incomplete ->
+          :incomplete
+      end
+    end
+  end
+
+  defp parse_bulk_strings(_count, _rest, _acc), do: :incomplete
+
+  defp parse_int_line(binary) do
+    case :binary.split(binary, "\r\n") do
+      [int_string, rest] -> {:ok, String.to_integer(int_string), rest}
+      [_no_crlf_yet] -> :incomplete
+    end
+  end
+
+  defp wait_until(fun, timeout \\ 2_000)
+  defp wait_until(_fun, timeout) when timeout <= 0, do: flunk("condition not met in time")
+
+  defp wait_until(fun, timeout) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(20)
+      wait_until(fun, timeout - 20)
+    end
+  end
+end

--- a/test/redix/cluster/redirection_test.exs
+++ b/test/redix/cluster/redirection_test.exs
@@ -18,10 +18,10 @@ defmodule Redix.Cluster.RedirectionTest do
 
     # The Manager normally owns this table; here we create it directly and route
     # slots ourselves. It dies with the test process. The marker mimics a cluster
-    # whose first topology fetch succeeded, so commands don't try to await the
+    # whose initial topology fetch completed, so commands don't try to await the
     # (nonexistent) Manager.
     :ets.new(:"#{cluster}_slots", [:named_table, :public, :set])
-    :ets.insert(:"#{cluster}_slots", {:topology_discovered, true})
+    :ets.insert(:"#{cluster}_slots", {:discovery_attempted, true})
 
     %{cluster: cluster}
   end

--- a/test/redix/cluster_test.exs
+++ b/test/redix/cluster_test.exs
@@ -433,6 +433,16 @@ defmodule Redix.ClusterTest do
         )
       end
     end
+
+    test ":exit_on_disconnection is not supported in cluster mode" do
+      assert_raise ArgumentError, ~r/:exit_on_disconnection option is not supported/, fn ->
+        Redix.Cluster.start_link(
+          name: :exit_on_disconnection_cluster_test,
+          nodes: @nodes,
+          exit_on_disconnection: true
+        )
+      end
+    end
   end
 
   describe "__parse_node__/1" do


### PR DESCRIPTION
Closes #320.

`Redix.Cluster.start_link/1` passes non-cluster options through to every node connection. With `exit_on_disconnection: true`, a single node outage makes its connection exit, the pool `DynamicSupervisor` restarts it, it exits again immediately, and the restart intensity is exceeded in milliseconds — escalating through the `:one_for_all` cluster supervisor and potentially into the host application's tree.

Per-connection exit semantics don't compose with the cluster's own restart/monitor machinery, so reject the option upfront with an `ArgumentError`, the same way `:sentinel` is already rejected. Also documents the two unsupported options in the `start_link/1` docs and adds a regression test.