### PR TITLE
Connect on demand for ASK redirects in cluster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,15 +169,19 @@ This eliminates the need for `persistent_term` or any external lookup.
   replicas}` mapping would otherwise route to a node that no longer owns the slot (issue
   #314). Lookups for a genuinely unassigned slot return `:error`, which is correct.
 
-- **MOVED redirects connect on demand.** When a `MOVED` points at a node not yet in the
-  Registry (typical mid-resharding: the topology refresh cast is async and the Manager
-  may be `:cooling_down`), `handle_moved_redirect/6` falls back to
+- **MOVED and ASK redirects connect on demand.** When a redirect points at a node not
+  yet in the Registry, `handle_moved_redirect/6` and `handle_ask_redirect/6` fall back to
   `Manager.connect_to_node/2` — a `:gen_statem.call` served in both `:ready` and
   `:cooling_down` that starts+monitors a connection to the redirect target and returns its
-  pid. `MOVED` is authoritative, so we trust the address rather than returning a fake
-  "unreachable" error. The next `ensure_connections` adopts the connection (if `CLUSTER
-  SLOTS` lists it) or terminates it (if not), so a bogus address can't leak connections.
-  The async refresh still fires to update the slot table for future routing.
+  pid. For `MOVED` the typical case is mid-resharding (the topology refresh cast is async
+  and the Manager may be `:cooling_down`); for `ASK` it's a slot migrating to a
+  *brand-new* node, which serves zero slots and so never appears in `CLUSTER SLOTS` —
+  without the fallback every ASK-redirected command would fail until the first migration
+  completed (issue #319). Redirects are authoritative, so we trust the address rather
+  than returning a fake "unreachable" error. The next `ensure_connections` adopts the
+  connection (if `CLUSTER SLOTS` lists it) or terminates it (if not), so a bogus address
+  can't leak connections. For `MOVED`, the async refresh still fires to update the slot
+  table for future routing.
 
 - **Redirect chains are followed, not just single hops.** `MOVED` and `ASK` both
   flow through `follow_redirections/5`, the single place the `@max_redirections`

--- a/lib/redix/cluster.ex
+++ b/lib/redix/cluster.ex
@@ -770,7 +770,20 @@ defmodule Redix.Cluster do
   end
 
   defp handle_ask_redirect(cluster, host, port, cmds, opts, remaining) do
-    case Manager.get_connection_by_node(registry_name(cluster), {host, port}) do
+    registry = registry_name(cluster)
+
+    # The classic ASK scenario is a slot migrating to a brand-new node: a node
+    # serving zero slots doesn't appear in CLUSTER SLOTS, so it has no Registry
+    # entry and no topology refresh will ever connect it. Like MOVED, fall back
+    # to connecting on demand — ASK targets are cluster members, and the next
+    # `ensure_connections` adopts or terminates the connection (issue #319).
+    conn =
+      case Manager.get_connection_by_node(registry, {host, port}) do
+        {:ok, conn} -> {:ok, conn}
+        :error -> Manager.connect_to_node(manager_name(cluster), {host, port})
+      end
+
+    case conn do
       {:ok, conn} ->
         # ASK is a per-command, per-request redirection: each command needs its
         # own ASKING prefix, and the target may redirect us again (ASK -> ASK or
@@ -780,7 +793,7 @@ defmodule Redix.Cluster do
           execute_asking_command(cluster, conn, indexed_cmd, opts, remaining)
         end)
 
-      :error ->
+      {:error, _reason} ->
         Enum.map(cmds, fn {idx, _cmd} ->
           {idx, %Redix.Error{message: "ASK to unreachable node #{host}:#{port}"}}
         end)

--- a/test/redix/cluster/redirection_test.exs
+++ b/test/redix/cluster/redirection_test.exs
@@ -112,6 +112,43 @@ defmodule Redix.Cluster.RedirectionTest do
     assert Redix.Cluster.command(cluster, ["GET", "x"]) == {:ok, "hello"}
   end
 
+  # Reproduces issue #319: the classic ASK scenario is a slot migrating to a
+  # brand-new node. A node serving zero slots doesn't appear in CLUSTER SLOTS at
+  # all, so the cluster has no connection to it and no topology refresh will
+  # create one — the redirection code must connect on demand (as it already does
+  # for MOVED) instead of failing every ASK-redirected command until the first
+  # migration completes. On-demand connects go through the Manager, so unlike
+  # the tests above this one boots a real Redix.Cluster against a fake node
+  # that claims all slots.
+  test "follows an ASK to a brand-new node that isn't in the topology yet" do
+    cluster = :"ask_new_node_#{System.unique_integer([:positive])}"
+    slot = Hash.hash_slot("x")
+
+    # The brand-new node receiving the migrating slot.
+    {listen_new, node_new} = raw_listen()
+
+    serve(listen_new, fn
+      ["ASKING"] -> "+OK\r\n"
+      ["GET", _] -> "$3\r\nbar\r\n"
+    end)
+
+    # The slot owner: answers the topology fetch claiming every slot, then ASKs
+    # the command onward to the new node.
+    {listen_owner, node_owner} = raw_listen()
+
+    serve(listen_owner, fn
+      ["CLUSTER", "SLOTS"] -> cluster_slots_reply(node_owner)
+      ["GET", _] -> "-ASK #{slot} #{node_new}\r\n"
+      _other -> "+OK\r\n"
+    end)
+
+    start_supervised!(
+      {Redix.Cluster, name: cluster, nodes: ["redis://#{node_owner}"], sync_connect: true}
+    )
+
+    assert Redix.Cluster.command(cluster, ["GET", "x"]) == {:ok, "bar"}
+  end
+
   # Reproduces issue #325: redirect messages are server-controlled input, so a
   # malformed MOVED/ASK from a buggy or hostile server must come back to the
   # caller as a plain Redis error instead of crashing the calling process with
@@ -151,6 +188,25 @@ defmodule Redix.Cluster.RedirectionTest do
     {listen, node_id} = listen(cluster)
     serve(listen, handler)
     node_id
+  end
+
+  # Like listen/1, but without starting (or registering) a connection to the
+  # node — for fake nodes the cluster must discover or connect to on its own.
+  defp raw_listen do
+    {:ok, listen} =
+      :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true, packet: :raw])
+
+    {:ok, port} = :inet.port(listen)
+    {listen, "127.0.0.1:#{port}"}
+  end
+
+  # Encodes a CLUSTER SLOTS reply with all 16384 slots owned by a single
+  # primary and no replicas: `[[0, 16383, [host, port, node_id]]]`.
+  defp cluster_slots_reply(node_id) do
+    [host, port] = String.split(node_id, ":")
+
+    "*1\r\n*3\r\n:0\r\n:16383\r\n*3\r\n" <>
+      "$#{byte_size(host)}\r\n#{host}\r\n:#{port}\r\n$40\r\n#{String.duplicate("a", 40)}\r\n"
   end
 
   defp listen(cluster) do
@@ -197,14 +253,22 @@ defmodule Redix.Cluster.RedirectionTest do
   end
 
   defp serve(listen, handler) do
-    test_pid = self()
+    spawn_link(fn -> accept_loop(listen, handler) end)
+  end
 
-    spawn_link(fn ->
-      case :gen_tcp.accept(listen, 5_000) do
-        {:ok, socket} -> loop(socket, handler, "")
-        {:error, _reason} -> Process.unlink(test_pid)
-      end
-    end)
+  # Accepts connections until the listen socket closes (when the owning test
+  # exits) or no client shows up for 5s. Some fake nodes get more than one
+  # connection — e.g. the Manager's transient topology-fetch socket plus the
+  # managed Redix connection.
+  defp accept_loop(listen, handler) do
+    case :gen_tcp.accept(listen, 5_000) do
+      {:ok, socket} ->
+        spawn_link(fn -> loop(socket, handler, "") end)
+        accept_loop(listen, handler)
+
+      {:error, _reason} ->
+        :ok
+    end
   end
 
   defp loop(socket, handler, buffer) do


### PR DESCRIPTION
Fixes #319.

`handle_ask_redirect/6` returned a fabricated `ASK to unreachable node host:port` error when the redirect target wasn't in the Registry. The classic ASK scenario is a slot migrating to a **brand-new node**: a node serving zero slots doesn't appear in `CLUSTER SLOTS` at all, so it has no Registry entry and no topology refresh will ever connect it — every ASK-redirected command failed until the first slot migration completed.

This mirrors the existing MOVED fallback (#293): on a Registry miss, connect on demand via `Manager.connect_to_node/2`. ASK targets are cluster members, and the next `ensure_connections` adopts or terminates the connection just like for MOVED, so a bogus address can't leak connections. The fabricated error is now only returned when `connect_to_node` itself fails.

The regression test follows the fake-RESP-node pattern: a real `Redix.Cluster` discovers topology from a fake node claiming all slots, which ASKs a command onward to a second fake node absent from `CLUSTER SLOTS`. Without the fix it fails with exactly the error from the issue; with it, the command succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)